### PR TITLE
Bump version to 0.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.zarr</groupId>
     <artifactId>zarr-java</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.4</version>
 
     <name>zarr-java</name>
 


### PR DESCRIPTION
In preparation of a release of zarr-java with the latest sharding improvements in #6 and #7. See https://github.com/zarr-developers/zarr-java/pull/7#issuecomment-2304631476 for issues with the `0.0.3` tag.

Proposing to tag a `0.0.4` release. Alternatively, we could delete the existing `0.0.3` tag (which artifacts never got promoted) and re-release `0.0.3`