### PR TITLE
Fix `HttpStore`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,17 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
           cache: maven
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Assemble JAR
         run: mvn package -DskipTests
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: jar
           path: target/*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: jar
+          name: jar-${{ runner.os }}
           path: target/*.jar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -32,7 +32,7 @@ jobs:
       # Begin copy from ci.yml. Refactor?
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Group hierarchy = Group.open(
     new HttpStore("https://static.webknossos.org/data/zarr_v3")
         .resolve("l4_sample")
 );
-Array array = hierarchy.get("color").get("1");
+Group color = (Group) hierarchy.get("color");
+Array array = (Array) color.get("1");
 ucar.ma2.Array outArray = array.read(
     new long[]{0, 3073, 3073, 513}, // offset
     new int[]{1, 64, 64, 64} // shape
@@ -31,11 +32,12 @@ Array array = Array.create(
         .withChunkShape(1, 1024, 1024, 1024)
         .withFillValue(0)
         .withCodecs(c -> c.withSharding(new int[]{1, 32, 32, 32}, c1 -> c1.withBlosc()))
-        .build();
+        .build()
 );
+ucar.ma2.Array data = ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{1, 1024, 1024, 1024});
 array.write(
     new long[]{0, 0, 0, 0}, // offset
-    ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{1, 1024, 1024, 1024})
+    data
 );
 ```
 ## Development Start-Guide

--- a/src/main/java/dev/zarr/zarrjava/store/HttpStore.java
+++ b/src/main/java/dev/zarr/zarrjava/store/HttpStore.java
@@ -79,7 +79,7 @@ public class HttpStore implements Store {
       throw new IllegalArgumentException("Argument 'start' needs to be non-negative.");
     }
     Request request = new Request.Builder().url(resolveKeys(keys)).header(
-        "Range", String.format("Bytes=%d-%d", start, end + 1)).build();
+        "Range", String.format("Bytes=%d-%d", start, end - 1)).build();
     return get(request);
   }
 

--- a/src/main/java/dev/zarr/zarrjava/v3/Array.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/Array.java
@@ -142,6 +142,11 @@ public class Array extends Node {
     if (shape.length != metadata.ndim()) {
       throw new IllegalArgumentException("'shape' needs to have rank '" + metadata.ndim() + "'.");
     }
+    for (int dimIdx = 0; dimIdx < metadata.ndim(); dimIdx++) {
+      if (offset[dimIdx] < 0 || offset[dimIdx] + shape[dimIdx] > metadata.shape[dimIdx]) {
+        throw new ZarrException("Requested data is outside of the array's domain.");
+      }
+    }
 
     final int[] chunkShape = metadata.chunkShape();
     if (IndexingUtils.isSingleFullChunk(offset, shape, chunkShape)) {

--- a/src/main/java/dev/zarr/zarrjava/v3/Array.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/Array.java
@@ -173,7 +173,9 @@ public class Array extends Node {
 
                 final String[] chunkKeys = metadata.chunkKeyEncoding.encodeChunkKey(chunkCoords);
                 final StoreHandle chunkHandle = storeHandle.resolve(chunkKeys);
-
+                if (!chunkHandle.exists()) {
+                  return;
+                }
                 if (codecPipeline.supportsPartialDecode()) {
                   final ucar.ma2.Array chunkArray = codecPipeline.decodePartial(chunkHandle,
                       Utils.toLongArray(chunkProjection.chunkOffset), chunkProjection.shape);

--- a/src/test/java/dev/zarr/zarrjava/ZarrTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrTest.java
@@ -235,10 +235,10 @@ public class ZarrTest {
 
     static Stream<Function<CodecBuilder, CodecBuilder>> invalidCodecBuilder() {
         return Stream.of(
-                c -> c.withBytes(BytesCodec.Endian.LITTLE).withBytes(BytesCodec.Endian.LITTLE),
-                c -> c.withBlosc().withBytes(BytesCodec.Endian.LITTLE),
-                c -> c.withBytes(BytesCodec.Endian.LITTLE).withTranspose(new int[]{1, 0}),
-                c -> c.withTranspose(new int[]{1, 0}).withBytes(BytesCodec.Endian.LITTLE).withTranspose(new int[]{1, 0})
+            c -> c.withBytes(BytesCodec.Endian.LITTLE).withBytes(BytesCodec.Endian.LITTLE),
+            c -> c.withBlosc().withBytes(BytesCodec.Endian.LITTLE),
+            c -> c.withBytes(BytesCodec.Endian.LITTLE).withTranspose(new int[]{1, 0}),
+            c -> c.withTranspose(new int[]{1, 0}).withBytes(BytesCodec.Endian.LITTLE).withTranspose(new int[]{1, 0})
         );
     }
 


### PR DESCRIPTION
This PR fixes the `HttpStore` which requested 2 bytes too many resulting in an error while decoding blosc.
- Fixes #10

Other changes:
- Updated and tested example in `README.md`
- Added test to compare results of reading from `HttpStore` and `FilesystemStore`
- better exception message if requested data is out of range of array
