### PR TITLE
Update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,12 @@
     <properties>
         <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson.version>2.14.2</jackson.version>
-        <aws.version>1.12.477</aws.version>
-        <netcdfJavaVersion>5.5.3</netcdfJavaVersion>
-        <zstdVersion>1.5.5-5</zstdVersion>
-        <junit-jupiter-version>5.10.2</junit-jupiter-version>
+        <jackson.version>2.20.0</jackson.version>
+        <aws.version>2.34.6</aws.version>
+        <netcdfJavaVersion>5.9.1</netcdfJavaVersion>
+        <zstdVersion>1.5.5-7</zstdVersion>
+        <junit-jupiter-version>5.14.0</junit-jupiter-version>
+        <findbugs.version>3.0.2</findbugs.version>
     </properties>
 
     <dependencies>
@@ -84,13 +85,18 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${findbugs.version}</version>
+        </dependency>
+        <dependency>
             <groupId>edu.ucar</groupId>
             <artifactId>cdm-core</artifactId>
             <version>${netcdfJavaVersion}</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>${aws.version}</version>
         </dependency>
         <dependency>

--- a/src/test/java/dev/zarr/zarrjava/ZarrTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrTest.java
@@ -1,8 +1,5 @@
 package dev.zarr.zarrjava;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.luben.zstd.Zstd;
@@ -20,6 +17,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import ucar.ma2.MAMath;
 
 import java.io.*;
@@ -280,9 +281,9 @@ public class ZarrTest {
 
     @Test
     public void testS3Store() throws IOException, ZarrException {
-        S3Store s3Store = new S3Store(AmazonS3ClientBuilder.standard()
-            .withRegion("eu-west-1")
-            .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+        S3Store s3Store = new S3Store(S3Client.builder()
+            .region(Region.of("eu-west-1"))
+            .credentialsProvider(AnonymousCredentialsProvider.create())
             .build(), "static.webknossos.org", "data");
         System.out.println(Array.open(s3Store.resolve("zarr_v3", "l4_sample", "color", "1")));
     }


### PR DESCRIPTION
This PR bumps the dependency versions to the latest available:

- jackson: 2.14.2 -> 2.20.0
- aws: 1.12.477 -> 2.34.6
- netcdfJavaVersion: 5.5.3 -> 5.9.1
- zstdVersion: 1.5.5-5 -> 1.5.5-7
- junit-jupiter-version: 5.10.2 -> 5.14.0

Or are there particular reasons to keep older versions?

For aws-skd v1 to v2 I used the migration tool mentioned https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/migration-tool.html . Tests are passing. But I'm not sure if the tests cover everything which is affected by this PR.

Background: I'd like to use zarr-java in [ZarrReader](https://github.com/ome/ZarrReader) and [omero-zarr-pixel-buffer](https://github.com/ome/omero-zarr-pixel-buffer) but struggle with dependency/version conflicts. So updating all to use the latest versions would hopefully solve this.
