### PR TITLE
Bump to 0.0.6 to trigger release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Publish package to the Maven Central Repository
 on:
   release:
-    types: [created]
+    types: [created, published]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.zarr</groupId>
     <artifactId>zarr-java</artifactId>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
 
     <name>zarr-java</name>
 


### PR DESCRIPTION
There are apparently cases where release: [created] leads to the deploy not being triggered. Attempting an expansion to [created, published].

cc: @brokkoli71 @normanrz @dominikl 