### PR TITLE
Publish thin main jar; move fat jar to shaded classifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,9 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>dev.zarr.zarrjava.cli.Main</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.zarr</groupId>
     <artifactId>zarr-java</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3-SNAPSHOT</version>
 
     <name>zarr-java</name>
 


### PR DESCRIPTION
# Summary

The maven-shade-plugin in the `pom.xml` currently replaces the main artifact with a fat jar and publishes a dependency-reduced POM. Library consumers therefore receive a jar bundling jackson-*, aws-sdk:s3, okhttp, commons-compress, etc., paired with a POM that declares no runtime dependencies.

When a downstream project depends on dev.zarr:zarr-java and also directly on any of those libraries (very common — e.g. Jackson is ubiquitous), `maven-enforcer-plugin's` `duplicate-class` / `upper-bound-deps` rules fail the build because the same classes appear both inside the shaded zarr-java jar and on the regular classpath. There is no clean way for the consumer to exclude them, since the POM hides the bundled coordinates.

# Change 
                                                                                                        
Switch the shade execution to attach the fat jar under a classifier rather than replacing the main artifact, and disable the dependency-reduced POM:                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                
```
   <shadedArtifactAttached>true</shadedArtifactAttached>                                                                                                                                                                                                                                                          
   <shadedClassifierName>shaded</shadedClassifierName>                                                                                                                                                                                                                                                          
   <createDependencyReducedPom>false</createDependencyReducedPom>  
```                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
# Released artifacts after this change:                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                  
  | artifact                 | contents                                                     | intended use                       |                                                                                                                                                                               
   |--------------------------|--------------------------------------------------------------|------------------------------------|                                                                                                                                                                             
   | zarr-java-<v>.jar        | only dev.zarr.* classes; full POM with normal <dependencies> | library consumers (Maven/Gradle)   |                                                                                                                                                                               
   | zarr-java-<v>-shaded.jar | fat jar with Main-Class: dev.zarr.zarrjava.cli.Main          | CLI users (java -jar …-shaded.jar) |                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                  
   CLI users who want the executable jar from Maven Central can pull it with <classifier>shaded</classifier>.                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                  
   Verified locally                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                
```
   - mvn -DskipTests package produces both jars.                                                                                                                                                                                                                                                                  
   - Thin jar contains only META-INF/ and dev/ (no bundled deps).
   - Shaded jar still has Main-Class: dev.zarr.zarrjava.cli.Main in its manifest.      
```                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                
# Notes / non-goals                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                                     
- Native libraries are unaffected: zstd-jni ships its own natives inside its jar (transitively resolved via the thin POM), and blosc-java continues to require the system libblosc library on the host (as already documented in .github/workflows/deploy.yml).
- No relocations are added. The shaded jar still bundles unrelocated com.fasterxml.jackson etc.; that's fine for the CLI use case and matches today's behavior.           