### PR TITLE
Fix S3 suffix byte-range requests when reading sharded chunks

### DIFF
--- a/src/main/java/dev/zarr/zarrjava/store/S3Store.java
+++ b/src/main/java/dev/zarr/zarrjava/store/S3Store.java
@@ -1,17 +1,28 @@
 package dev.zarr.zarrjava.store;
 
-import dev.zarr.zarrjava.utils.Utils;
-import software.amazon.awssdk.core.ResponseInputStream;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.*;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import dev.zarr.zarrjava.utils.Utils;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.S3Object;
 
 public class S3Store implements Store, Store.ListableStore {
 
@@ -82,7 +93,9 @@ public class S3Store implements Store, Store.ListableStore {
         GetObjectRequest req = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(resolveKeys(keys))
-                .range(String.format("bytes=%d-", start))
+                  .range(start < 0 //dependant on where we start either fetch last or first bytes
+                    ? String.format("bytes=%d", start)
+                    : String.format("bytes=%d-", start))
                 .build();
         return get(req);
     }

--- a/src/main/java/dev/zarr/zarrjava/store/S3Store.java
+++ b/src/main/java/dev/zarr/zarrjava/store/S3Store.java
@@ -93,7 +93,7 @@ public class S3Store implements Store, Store.ListableStore {
         GetObjectRequest req = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(resolveKeys(keys))
-                  .range(start < 0 //dependant on where we start either fetch last or first bytes
+                  .range(start < 0 // negative start implies indexing from the end, i.e. last bytes
                     ? String.format("bytes=%d", start)
                     : String.format("bytes=%d-", start))
                 .build();

--- a/src/test/java/dev/zarr/zarrjava/store/OnlineS3StoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/OnlineS3StoreTest.java
@@ -65,9 +65,7 @@ public class OnlineS3StoreTest extends StoreTest {
         StoreHandle storeHandle = storeHandleWithData();
         ByteBuffer fullBuffer = storeHandle.read();
         long size = fullBuffer.remaining();
-        if (size < 20) {
-            Assertions.fail("Store size is too small to test suffix read");
-        }
+        Assertions.assertsTrue(size >= 20, "Store size is too small to test suffix read");
 
         ByteBuffer suffixBuffer = storeHandle.read(-10);
         Assertions.assertEquals(10, suffixBuffer.remaining());

--- a/src/test/java/dev/zarr/zarrjava/store/OnlineS3StoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/OnlineS3StoreTest.java
@@ -65,7 +65,7 @@ public class OnlineS3StoreTest extends StoreTest {
         StoreHandle storeHandle = storeHandleWithData();
         ByteBuffer fullBuffer = storeHandle.read();
         long size = fullBuffer.remaining();
-        Assertions.assertsTrue(size >= 20, "Store size is too small to test suffix read");
+        Assertions.assertTrue(size >= 20, "Store size is too small to test suffix read");
 
         ByteBuffer suffixBuffer = storeHandle.read(-10);
         Assertions.assertEquals(10, suffixBuffer.remaining());

--- a/src/test/java/dev/zarr/zarrjava/store/OnlineS3StoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/OnlineS3StoreTest.java
@@ -60,6 +60,26 @@ public class OnlineS3StoreTest extends StoreTest {
         Assertions.assertEquals(10, bufferWithStartAndEnd.remaining());
     }
 
+    @Test
+    public void testReadSuffix() {
+        StoreHandle storeHandle = storeHandleWithData();
+        ByteBuffer fullBuffer = storeHandle.read();
+        long size = fullBuffer.remaining();
+        if (size < 20) {
+            Assertions.fail("Store size is too small to test suffix read");
+        }
+
+        ByteBuffer suffixBuffer = storeHandle.read(-10);
+        Assertions.assertEquals(10, suffixBuffer.remaining());
+
+        byte[] expectedBytes = new byte[10];
+        fullBuffer.position((int) (size - 10));
+        fullBuffer.get(expectedBytes);
+        byte[] actualBytes = new byte[10];
+        suffixBuffer.get(actualBytes);
+        Assertions.assertArrayEquals(expectedBytes, actualBytes);
+    }
+
     @Override
     StoreHandle storeHandleWithData() {
         return storeHandle.resolve("zarr.json");

--- a/src/test/java/dev/zarr/zarrjava/store/StoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/StoreTest.java
@@ -106,6 +106,26 @@ public abstract class StoreTest extends ZarrTest {
     }
 
     @Test
+    public void testReadSuffix() {
+        StoreHandle storeHandle = storeHandleWithData();
+        ByteBuffer fullBuffer = storeHandle.read();
+        long size = fullBuffer.remaining();
+        if (size < 20) {
+            Assertions.fail("Store size is too small to test suffix read");
+        }
+
+        ByteBuffer suffixBuffer = storeHandle.read(-10);
+        Assertions.assertEquals(10, suffixBuffer.remaining());
+
+        byte[] expectedBytes = new byte[10];
+        fullBuffer.position((int) (size - 10));
+        fullBuffer.get(expectedBytes);
+        byte[] actualBytes = new byte[10];
+        suffixBuffer.get(actualBytes);
+        Assertions.assertArrayEquals(expectedBytes, actualBytes);
+    }
+
+    @Test
     public abstract void testList() throws ZarrException, IOException;
 
     byte[] testData() {

--- a/src/test/java/dev/zarr/zarrjava/store/StoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/StoreTest.java
@@ -106,26 +106,6 @@ public abstract class StoreTest extends ZarrTest {
     }
 
     @Test
-    public void testReadSuffix() {
-        StoreHandle storeHandle = storeHandleWithData();
-        ByteBuffer fullBuffer = storeHandle.read();
-        long size = fullBuffer.remaining();
-        if (size < 20) {
-            Assertions.fail("Store size is too small to test suffix read");
-        }
-
-        ByteBuffer suffixBuffer = storeHandle.read(-10);
-        Assertions.assertEquals(10, suffixBuffer.remaining());
-
-        byte[] expectedBytes = new byte[10];
-        fullBuffer.position((int) (size - 10));
-        fullBuffer.get(expectedBytes);
-        byte[] actualBytes = new byte[10];
-        suffixBuffer.get(actualBytes);
-        Assertions.assertArrayEquals(expectedBytes, actualBytes);
-    }
-
-    @Test
     public abstract void testList() throws ZarrException, IOException;
 
     byte[] testData() {


### PR DESCRIPTION

  Reading a single chunk from a sharded array stored on S3 failed with a checksum                                                                                                                        
  error. To locate a chunk inside a shard, the sharding codec first reads the shard                                                                                                                      
  index at the *end* of the shard object via a suffix read                                                                                                                                               
  (`StoreHandle.read(-indexByteLength)`).                                                                                                                                                                
                                                                                                                                                                                                         
  `S3Store.get(long start, ...)` always formatted the HTTP range header as                                                                                                                               
  `bytes=<start>-`. For a negative start this produced an invalid header like                                                                                                                            
  `bytes=-16389-`, which S3 does not accept as a suffix range, causing the request                                                                                                                       
  to fail.                                                                                                                                                                                               
                                                                                                                                                                                                         
  ## Fix                                                                                                                                                                                                 
                                                                                                                                                                                                         
  When `start` is negative, emit the correct suffix-range form:
                                                                                                                                
  `bytes=-<N>`
  
   instead of `bytes=<start>-`.                                                                                                                                   
                                                                                                                                                                                                         
  ## Testing                                                                                                                                                                                             
                                                                                                                                                                                                         
  Added `testReadSuffix` to `StoreTest`, verifying that a suffix read returns                                                                                                                            
  exactly the last 10 bytes of the object.                                                                                            