### PR TITLE
add reshape codec

### DIFF
--- a/src/main/java/dev/zarr/zarrjava/v3/codec/CodecBuilder.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/CodecBuilder.java
@@ -64,6 +64,15 @@ public class CodecBuilder extends dev.zarr.zarrjava.core.codec.CodecBuilder {
         return this;
     }
 
+    /**
+     * Adds a {@code reshape} codec. Each entry of {@code shape} must be a positive {@link Integer}, the
+     * special value {@code -1} (at most once), or an {@code int[]} / array of input dimension indices.
+     */
+    public CodecBuilder withReshape(Object[] shape) {
+        codecs.add(new ReshapeCodec(new ReshapeCodec.Configuration(shape)));
+        return this;
+    }
+
     public CodecBuilder withBytes(Endian endian) {
         if (dataType.getByteCount() <= 1)
             codecs.add(new BytesCodec());

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/CodecRegistry.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/CodecRegistry.java
@@ -12,6 +12,7 @@ public class CodecRegistry {
 
     static {
         addType("transpose", TransposeCodec.class);
+        addType("reshape", ReshapeCodec.class);
         addType("bytes", BytesCodec.class);
         addType("blosc", BloscCodec.class);
         addType("gzip", GzipCodec.class);

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/ReshapeCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/ReshapeCodec.java
@@ -39,11 +39,26 @@ public class ReshapeCodec extends ArrayArrayCodec implements Codec {
     @Nonnull
     public final Configuration configuration;
 
+    /**
+     * The resolved (and validated) output chunk shape. It depends only on {@code arrayMetadata.chunkShape}
+     * and is therefore computed once in {@link #setCoreArrayMetadata} rather than on every encode/decode.
+     */
+    @JsonIgnore
+    protected int[] outputChunkShape;
+
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public ReshapeCodec(
             @Nonnull @JsonProperty(value = "configuration", required = true) Configuration configuration
     ) {
         this.configuration = configuration;
+    }
+
+    @Override
+    public void setCoreArrayMetadata(ArrayMetadata.CoreArrayMetadata arrayMetadata) throws ZarrException {
+        super.setCoreArrayMetadata(arrayMetadata);
+        // Resolve and validate the output shape once, here, because it only changes when the
+        // arrayMetadata changes. encode/decode/resolveArrayMetadata then reuse the cached value.
+        this.outputChunkShape = resolveOutputShape(arrayMetadata.chunkShape);
     }
 
     @Override
@@ -54,20 +69,18 @@ public class ReshapeCodec extends ArrayArrayCodec implements Codec {
                     "reshape codec received an array of shape " + Arrays.toString(chunkArray.getShape())
                             + " but expected the chunk shape " + Arrays.toString(inputShape) + ".");
         }
-        int[] outputShape = resolveOutputShape(inputShape);
         // Array.reshape copies the elements in lexicographical (C) order, hence ravel(B) == ravel(A)
         // even when the input array is a non-contiguous view.
-        return chunkArray.reshape(outputShape);
+        return chunkArray.reshape(outputChunkShape);
     }
 
     @Override
     public Array decode(Array chunkArray) throws ZarrException {
         int[] inputShape = arrayMetadata.chunkShape;
-        int[] outputShape = resolveOutputShape(inputShape);
-        if (!Arrays.equals(chunkArray.getShape(), outputShape)) {
+        if (!Arrays.equals(chunkArray.getShape(), outputChunkShape)) {
             throw new ZarrException(
                     "reshape codec received an array of shape " + Arrays.toString(chunkArray.getShape())
-                            + " but expected the reshaped shape " + Arrays.toString(outputShape) + ".");
+                            + " but expected the reshaped shape " + Arrays.toString(outputChunkShape) + ".");
         }
         // Inverse operation: reshape back to the original chunk shape.
         return chunkArray.reshape(inputShape);
@@ -85,7 +98,6 @@ public class ReshapeCodec extends ArrayArrayCodec implements Codec {
         super.resolveArrayMetadata();
 
         int[] inputChunkShape = arrayMetadata.chunkShape;
-        int[] outputChunkShape = resolveOutputShape(inputChunkShape);
 
         // Derive the output (grid) array shape so that number of chunks along each output dimension is
         // consistent with the input. For a merged output dimension this is the product of the input

--- a/src/main/java/dev/zarr/zarrjava/v3/codec/core/ReshapeCodec.java
+++ b/src/main/java/dev/zarr/zarrjava/v3/codec/core/ReshapeCodec.java
@@ -1,0 +1,392 @@
+package dev.zarr.zarrjava.v3.codec.core;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.zarr.zarrjava.ZarrException;
+import dev.zarr.zarrjava.core.codec.ArrayArrayCodec;
+import dev.zarr.zarrjava.v3.ArrayMetadata;
+import dev.zarr.zarrjava.v3.codec.Codec;
+import ucar.ma2.Array;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * {@code array -> array} codec that reshapes a chunk.
+ *
+ * <p>The codec preserves the (logical) lexicographical / C-order traversal of the elements, i.e.
+ * {@code ravel(B) == ravel(A)}. It never transposes; combine it with the {@code transpose} codec if
+ * a reordering is also required.
+ *
+ * <p>The target {@code shape} is described relative to the input (chunk) shape {@code A_shape}. Each
+ * entry is one of:
+ * <ul>
+ *   <li>a positive integer {@code size}, giving {@code B_shape[i] == size};</li>
+ *   <li>an array of input dimension indices {@code input_dims}, giving
+ *   {@code B_shape[i] == prod(A_shape[input_dims])};</li>
+ *   <li>the special value {@code -1} (at most once), inferred so that
+ *   {@code prod(B_shape) == prod(A_shape)}.</li>
+ * </ul>
+ */
+public class ReshapeCodec extends ArrayArrayCodec implements Codec {
+
+    @JsonIgnore
+    @Nonnull
+    public final String name = "reshape";
+    @Nonnull
+    public final Configuration configuration;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public ReshapeCodec(
+            @Nonnull @JsonProperty(value = "configuration", required = true) Configuration configuration
+    ) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Array encode(Array chunkArray) throws ZarrException {
+        int[] inputShape = arrayMetadata.chunkShape;
+        if (!Arrays.equals(chunkArray.getShape(), inputShape)) {
+            throw new ZarrException(
+                    "reshape codec received an array of shape " + Arrays.toString(chunkArray.getShape())
+                            + " but expected the chunk shape " + Arrays.toString(inputShape) + ".");
+        }
+        int[] outputShape = resolveOutputShape(inputShape);
+        // Array.reshape copies the elements in lexicographical (C) order, hence ravel(B) == ravel(A)
+        // even when the input array is a non-contiguous view.
+        return chunkArray.reshape(outputShape);
+    }
+
+    @Override
+    public Array decode(Array chunkArray) throws ZarrException {
+        int[] inputShape = arrayMetadata.chunkShape;
+        int[] outputShape = resolveOutputShape(inputShape);
+        if (!Arrays.equals(chunkArray.getShape(), outputShape)) {
+            throw new ZarrException(
+                    "reshape codec received an array of shape " + Arrays.toString(chunkArray.getShape())
+                            + " but expected the reshaped shape " + Arrays.toString(outputShape) + ".");
+        }
+        // Inverse operation: reshape back to the original chunk shape.
+        return chunkArray.reshape(inputShape);
+    }
+
+    @Override
+    public long computeEncodedSize(long inputByteLength,
+                                   ArrayMetadata.CoreArrayMetadata arrayMetadata) throws ZarrException {
+        // Reshaping does not add or remove any elements.
+        return inputByteLength;
+    }
+
+    @Override
+    public ArrayMetadata.CoreArrayMetadata resolveArrayMetadata() throws ZarrException {
+        super.resolveArrayMetadata();
+
+        int[] inputChunkShape = arrayMetadata.chunkShape;
+        int[] outputChunkShape = resolveOutputShape(inputChunkShape);
+
+        // Derive the output (grid) array shape so that number of chunks along each output dimension is
+        // consistent with the input. For a merged output dimension this is the product of the input
+        // chunk counts; a split input dimension keeps its chunk count on the outermost output dimension.
+        long[] inputArrayShape = arrayMetadata.shape;
+        long[] gridMultiplier = new long[outputChunkShape.length];
+        Arrays.fill(gridMultiplier, 1L);
+
+        long[] outputStart = new long[outputChunkShape.length + 1];
+        outputStart[0] = 1L;
+        for (int i = 0; i < outputChunkShape.length; i++) {
+            outputStart[i + 1] = outputStart[i] * outputChunkShape[i];
+        }
+
+        long inputStart = 1L;
+        for (int d = 0; d < inputChunkShape.length; d++) {
+            long numChunks = inputArrayShape[d] / inputChunkShape[d];
+            // Attach the chunk count of input dimension d to the output dimension whose flat range
+            // contains the start of input dimension d.
+            int target = outputChunkShape.length - 1;
+            for (int i = 0; i < outputChunkShape.length; i++) {
+                if (inputStart >= outputStart[i] && inputStart < outputStart[i + 1]) {
+                    target = i;
+                    break;
+                }
+            }
+            gridMultiplier[target] *= numChunks;
+            inputStart *= inputChunkShape[d];
+        }
+
+        long[] outputArrayShape = new long[outputChunkShape.length];
+        for (int i = 0; i < outputChunkShape.length; i++) {
+            outputArrayShape[i] = gridMultiplier[i] * outputChunkShape[i];
+        }
+
+        return new ArrayMetadata.CoreArrayMetadata(
+                outputArrayShape,
+                outputChunkShape,
+                arrayMetadata.dataType,
+                arrayMetadata.parsedFillValue
+        );
+    }
+
+    /**
+     * Resolves the concrete output shape {@code B_shape} from the {@code shape} configuration and the
+     * given input  shape {@code A_shape}, validating all invariants mandated by the specification.
+     */
+    int[] resolveOutputShape(int[] inputShape) throws ZarrException {
+        long inputTotal = product(inputShape);
+
+        // read the 'shape' config into a concrete (still -1-placeholder) output shape.
+        ParsedShape parsed = parseConfiguredShape(inputShape);
+        
+        // reject configs that reorder input dimensions (use transport for them).
+        checkNoReordering(parsed.flatInputDims);
+        
+        // fill in the single -1 entry, if present, so the element count matches.
+        resolveInferredDimension(parsed.outputShape, parsed.minusOnePos, inputTotal);
+        
+        // The fundamental reshape law, prod(output) == prod(input).
+        checkElementCountPreserved(parsed.outputShape, inputTotal);
+        
+        // Every merge entry must combine adjacent input dims sitting in the same flat position.
+        checkMergesAligned(parsed.outputShape, parsed.inputDimsPerOutput, inputShape);
+        
+        // Narrow long -> int for the array API.
+        return toIntShape(parsed.outputShape);
+    }
+
+    /**
+     * Product of all entries of {@code shape}, computed in {@code long} to avoid overflow.
+     */
+    private static long product(int[] shape) {
+        long total = 1L;
+        for (int size : shape) {
+            total *= size;
+        }
+        return total;
+    }
+
+    /**
+     * Step 1. Reads {@code configuration.shape} into the intermediate {@link ParsedShape}: each entry
+     * becomes a literal size, a {@code -1} placeholder, or the product of the merged input dimensions.
+     */
+    private ParsedShape parseConfiguredShape(int[] inputShape) throws ZarrException {
+        int ndim = inputShape.length;
+        int n = configuration.shape.length;
+        if (n == 0) {
+            throw new ZarrException("reshape codec: 'shape' must not be empty.");
+        }
+
+        long[] outputShape = new long[n];
+        int[][] inputDimsPerOutput = new int[n][];
+        int minusOnePos = -1;
+        List<Integer> flatInputDims = new ArrayList<>();
+
+        for (int i = 0; i < n; i++) {
+            Object element = configuration.shape[i];
+            int[] inputDims = asInputDims(element);
+            if (inputDims == null) {
+                int size = asInteger(element);
+                if (size == -1) {
+                    if (minusOnePos != -1) {
+                        throw new ZarrException("reshape codec: 'shape' may contain -1 at most once.");
+                    }
+                    minusOnePos = i;
+                    outputShape[i] = -1;
+                } else if (size <= 0) {
+                    throw new ZarrException(
+                            "reshape codec: 'shape' entries must be a positive integer, -1, or an array of "
+                                    + "input dimensions, but got " + size + ".");
+                } else {
+                    outputShape[i] = size;
+                }
+            } else {
+                inputDimsPerOutput[i] = inputDims;
+                long product = 1L;
+                for (int d : inputDims) {
+                    if (d < 0 || d >= ndim) {
+                        throw new ZarrException(
+                                "reshape codec: input dimension " + d + " is out of range for an input array with "
+                                        + ndim + " dimensions.");
+                    }
+                    product *= inputShape[d];
+                    flatInputDims.add(d);
+                }
+                outputShape[i] = product;
+            }
+        }
+        return new ParsedShape(outputShape, inputDimsPerOutput, minusOnePos, flatInputDims);
+    }
+
+    /**
+     * Step 2. The flattened list of referenced input dimensions must be strictly increasing. This rules
+     * out configurations that would (incorrectly) suggest a transpose.
+     */
+    private static void checkNoReordering(List<Integer> flatInputDims) throws ZarrException {
+        for (int j = 1; j < flatInputDims.size(); j++) {
+            if (flatInputDims.get(j) <= flatInputDims.get(j - 1)) {
+                throw new ZarrException(
+                        "reshape codec: the flattened list of input dimensions must be strictly increasing, but got "
+                                + flatInputDims + ".");
+            }
+        }
+    }
+
+    /**
+     * Step 3. Resolves the automatic dimension ({@code -1}) so that {@code prod(output) == prod(input)}.
+     */
+    private static void resolveInferredDimension(long[] outputShape, int minusOnePos, long inputTotal)
+            throws ZarrException {
+        if (minusOnePos == -1) {
+            return;
+        }
+        long known = 1L;
+        for (int i = 0; i < outputShape.length; i++) {
+            if (i != minusOnePos) {
+                known *= outputShape[i];
+            }
+        }
+        if (known == 0 || inputTotal % known != 0) {
+            throw new ZarrException(
+                    "reshape codec: cannot infer the -1 dimension because prod(output shape) would not equal "
+                            + "prod(input shape) (" + inputTotal + ").");
+        }
+        outputShape[minusOnePos] = inputTotal / known;
+    }
+
+    /**
+     * Step 4. Invariant: {@code prod(B_shape) == prod(A_shape)}. A reshape never changes the element count.
+     */
+    private static void checkElementCountPreserved(long[] outputShape, long inputTotal) throws ZarrException {
+        long outputTotal = 1L;
+        for (long size : outputShape) {
+            outputTotal *= size;
+        }
+        if (outputTotal != inputTotal) {
+            throw new ZarrException(
+                    "reshape codec: prod(output shape)=" + outputTotal + " does not equal prod(input shape)="
+                            + inputTotal + ".");
+        }
+    }
+
+    /**
+     * Step 5. For each output dimension specified by input dimensions, verify that the merged input
+     * dimensions actually correspond to the raveled index along that output dimension: the flat range
+     * before and after the merged block must match the flat range before and after the output dimension.
+     * This is a pure check &mdash; it never modifies {@code outputShape}.
+     */
+    private static void checkMergesAligned(long[] outputShape, int[][] inputDimsPerOutput, int[] inputShape)
+            throws ZarrException {
+        int n = outputShape.length;
+        int ndim = inputShape.length;
+        for (int i = 0; i < n; i++) {
+            int[] inputDims = inputDimsPerOutput[i];
+            if (inputDims == null || inputDims.length == 0) {
+                continue;
+            }
+            long outputPrefix = 1L;
+            for (int j = 0; j < i; j++) {
+                outputPrefix *= outputShape[j];
+            }
+            long outputSuffix = 1L;
+            for (int j = i + 1; j < n; j++) {
+                outputSuffix *= outputShape[j];
+            }
+            long inputPrefix = 1L;
+            for (int d = 0; d < inputDims[0]; d++) {
+                inputPrefix *= inputShape[d];
+            }
+            long inputSuffix = 1L;
+            for (int d = inputDims[inputDims.length - 1] + 1; d < ndim; d++) {
+                inputSuffix *= inputShape[d];
+            }
+            if (outputPrefix != inputPrefix || outputSuffix != inputSuffix) {
+                throw new ZarrException(
+                        "reshape codec: output dimension " + i + " specified by input dimensions "
+                                + Arrays.toString(inputDims) + " does not align with the raveled input array "
+                                + "(prefix " + outputPrefix + " vs " + inputPrefix + ", suffix " + outputSuffix
+                                + " vs " + inputSuffix + ").");
+            }
+        }
+    }
+
+    /**
+     * Step 6. Narrows the resolved {@code long} shape to {@code int[]} (the array API type), rejecting
+     * any dimension that would not fit.
+     */
+    private static int[] toIntShape(long[] outputShape) throws ZarrException {
+        int[] result = new int[outputShape.length];
+        for (int i = 0; i < outputShape.length; i++) {
+            if (outputShape[i] > Integer.MAX_VALUE) {
+                throw new ZarrException("reshape codec: output dimension " + i + " exceeds Integer.MAX_VALUE.");
+            }
+            result[i] = (int) outputShape[i];
+        }
+        return result;
+    }
+
+    /**
+     * Intermediate result of {@link #parseConfiguredShape}: the (possibly still {@code -1}-containing)
+     * output shape plus the bookkeeping the later validation steps need.
+     */
+    private static final class ParsedShape {
+        /** Output shape; the {@code -1} entry (if any) is still a placeholder until step 3. */
+        final long[] outputShape;
+        /** Per output dimension, the merged input dims (or {@code null} for a literal/{@code -1} entry). */
+        final int[][] inputDimsPerOutput;
+        /** Index of the single {@code -1} entry, or {@code -1} if there is none. */
+        final int minusOnePos;
+        /** All referenced input dimensions, flattened in reading order (used by the no-reorder check). */
+        final List<Integer> flatInputDims;
+
+        ParsedShape(long[] outputShape, int[][] inputDimsPerOutput, int minusOnePos,
+                    List<Integer> flatInputDims) {
+            this.outputShape = outputShape;
+            this.inputDimsPerOutput = inputDimsPerOutput;
+            this.minusOnePos = minusOnePos;
+            this.flatInputDims = flatInputDims;
+        }
+    }
+
+    private static int[] asInputDims(Object element) throws ZarrException {
+        if (element instanceof int[]) {
+            return (int[]) element;
+        }
+        if (element instanceof Object[]) {
+            Object[] array = (Object[]) element;
+            int[] dims = new int[array.length];
+            for (int i = 0; i < array.length; i++) {
+                dims[i] = asInteger(array[i]);
+            }
+            return dims;
+        }
+        if (element instanceof List) {
+            List<?> list = (List<?>) element;
+            int[] dims = new int[list.size()];
+            for (int i = 0; i < list.size(); i++) {
+                dims[i] = asInteger(list.get(i));
+            }
+            return dims;
+        }
+        return null;
+    }
+
+    private static int asInteger(Object element) throws ZarrException {
+        if (element instanceof Number) {
+            return ((Number) element).intValue();
+        }
+        throw new ZarrException(
+            "reshape codec: 'shape' entries must be integers or arrays of integers, but got " + element + "."
+        );
+    }
+
+    public static final class Configuration {
+        @Nonnull
+        public final Object[] shape;
+
+        @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+        public Configuration(@Nonnull @JsonProperty(value = "shape", required = true) Object[] shape) {
+            this.shape = shape;
+        }
+    }
+}

--- a/src/test/java/dev/zarr/zarrjava/ReshapeCodecTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ReshapeCodecTest.java
@@ -150,10 +150,10 @@ public class ReshapeCodecTest extends ZarrTest {
 
     @ParameterizedTest
     @MethodSource("invalidReshapes")
-    public void testReshapeInvalidConfig(int[] inputShape, Object[] shape) throws ZarrException {
-        ReshapeCodec codec = reshapeCodec(shape, inputShape);
-        ucar.ma2.Array input = sequential(inputShape);
-        assertThrows(ZarrException.class, () -> codec.encode(input));
+    public void testReshapeInvalidConfig(int[] inputShape, Object[] shape) {
+        // Invalid configurations are rejected eagerly when the array metadata is set (i.e. at pipeline
+        // construction time), not lazily on the first encode/decode.
+        assertThrows(ZarrException.class, () -> reshapeCodec(shape, inputShape));
     }
 
     @Test

--- a/src/test/java/dev/zarr/zarrjava/ReshapeCodecTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ReshapeCodecTest.java
@@ -1,0 +1,253 @@
+package dev.zarr.zarrjava;
+
+import dev.zarr.zarrjava.store.FilesystemStore;
+import dev.zarr.zarrjava.store.StoreHandle;
+import dev.zarr.zarrjava.v3.Array;
+import dev.zarr.zarrjava.v3.ArrayMetadata;
+import dev.zarr.zarrjava.v3.ArrayMetadataBuilder;
+import dev.zarr.zarrjava.v3.DataType;
+import dev.zarr.zarrjava.v3.codec.core.ReshapeCodec;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import ucar.ma2.MAMath;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertThrows;
+
+public class ReshapeCodecTest extends ZarrTest {
+
+    /**
+     * Builds a {@link ReshapeCodec} whose input array is a single chunk of shape {@code inputShape}.
+     */
+    private static ReshapeCodec reshapeCodec(Object[] shape, int[] inputShape) throws ZarrException {
+        ReshapeCodec codec = new ReshapeCodec(new ReshapeCodec.Configuration(shape));
+        codec.setCoreArrayMetadata(new ArrayMetadata.CoreArrayMetadata(
+                Arrays.stream(inputShape).asLongStream().toArray(),
+                inputShape,
+                DataType.UINT32,
+                null));
+        return codec;
+    }
+
+    private static ucar.ma2.Array sequential(int[] shape) {
+        int size = Arrays.stream(shape).reduce(1, (a, b) -> a * b);
+        int[] data = new int[size];
+        Arrays.setAll(data, p -> p);
+        return ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, shape, data);
+    }
+
+    static Stream<Arguments> validReshapes() {
+        return Stream.of(
+                // merge two leading dims
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{new int[]{0, 1}, new int[]{2}}, new int[]{6, 4}),
+                // flatten everything with an explicit product-of-all
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{new int[]{0, 1, 2}}, new int[]{24}),
+                // flatten everything with -1
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{-1}, new int[]{24}),
+                // spec example (scaled down): [[0,1],[2],3]
+                Arguments.of(new int[]{4, 5, 6, 3}, new Object[]{new int[]{0, 1}, new int[]{2}, 3}, new int[]{20, 6, 3}),
+                // split a dimension with explicit sizes
+                Arguments.of(new int[]{6, 4}, new Object[]{2, 3, 4}, new int[]{2, 3, 4}),
+                // introduce a leading singleton dimension (squeeze/unsqueeze use case)
+                Arguments.of(new int[]{4, 4}, new Object[]{1, new int[]{0}, new int[]{1}}, new int[]{1, 4, 4}),
+                // -1 combined with an explicit size
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{6, -1}, new int[]{6, 4}),
+                // -1 combined with input_dims
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{new int[]{0}, -1}, new int[]{2, 12}),
+                // identity reshape
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{new int[]{0}, new int[]{1}, new int[]{2}}, new int[]{2, 3, 4}),
+                // trailing singleton dimension
+                Arguments.of(new int[]{2, 3}, new Object[]{new int[]{0}, new int[]{1}, 1}, new int[]{2, 3, 1}),
+                // high-dimensional -> 1D (motivating zfp/image use case)
+                Arguments.of(new int[]{2, 2, 2, 2, 2}, new Object[]{-1}, new int[]{32})
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validReshapes")
+    public void testReshapeRoundTrip(int[] inputShape, Object[] shape, int[] expectedOutputShape)
+            throws ZarrException {
+        ReshapeCodec codec = reshapeCodec(shape, inputShape);
+
+        ucar.ma2.Array input = sequential(inputShape);
+        ucar.ma2.Array encoded = codec.encode(input);
+
+        // Output shape matches the specification.
+        Assertions.assertArrayEquals(expectedOutputShape, encoded.getShape());
+        // The lexicographical (C-order) ravel is preserved: ravel(B) == ravel(A).
+        Assertions.assertArrayEquals(
+                (int[]) input.get1DJavaArray(ucar.ma2.DataType.UINT),
+                (int[]) encoded.get1DJavaArray(ucar.ma2.DataType.UINT));
+
+        // decode is the inverse of encode.
+        ucar.ma2.Array decoded = codec.decode(encoded);
+        Assertions.assertArrayEquals(inputShape, decoded.getShape());
+        assert MAMath.equals(input, decoded);
+    }
+
+    @Test
+    public void testResolveArrayMetadataMergesChunkGrid() throws ZarrException {
+        // 8x6 array, 4x3 chunks -> 2x2 chunk grid. Merging both dims yields a 1D chunk of 12 elements
+        // and the chunk counts multiply into the single output dimension: 4 chunks * 12 = 48.
+        ReshapeCodec codec = new ReshapeCodec(new ReshapeCodec.Configuration(new Object[]{new int[]{0, 1}}));
+        codec.setCoreArrayMetadata(new ArrayMetadata.CoreArrayMetadata(
+                new long[]{8, 6},
+                new int[]{4, 3},
+                DataType.UINT32,
+                null));
+
+        ArrayMetadata.CoreArrayMetadata resolved = codec.resolveArrayMetadata();
+        Assertions.assertArrayEquals(new int[]{12}, resolved.chunkShape);
+        Assertions.assertArrayEquals(new long[]{48}, resolved.shape);
+    }
+
+    @Test
+    public void testResolveArrayMetadataKeepsGridPerOutputDim() throws ZarrException {
+        // 8x6x4 array, 4x3x4 chunks -> 2x2x1 chunk grid. shape=[[0,1],[2]] merges the first two dims;
+        // their chunk counts (2*2=4) attach to output dim 0, dim 1 keeps its single chunk.
+        ReshapeCodec codec = new ReshapeCodec(
+                new ReshapeCodec.Configuration(new Object[]{new int[]{0, 1}, new int[]{2}}));
+        codec.setCoreArrayMetadata(new ArrayMetadata.CoreArrayMetadata(
+                new long[]{8, 6, 4},
+                new int[]{4, 3, 4},
+                DataType.UINT32,
+                null));
+
+        ArrayMetadata.CoreArrayMetadata resolved = codec.resolveArrayMetadata();
+        Assertions.assertArrayEquals(new int[]{12, 4}, resolved.chunkShape);
+        Assertions.assertArrayEquals(new long[]{48, 4}, resolved.shape);
+    }
+
+    static Stream<Arguments> invalidReshapes() {
+        return Stream.of(
+                // product mismatch
+                Arguments.of(new int[]{2, 3}, new Object[]{5}),
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{7, -1}),
+                // more than one -1
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{-1, -1}),
+                // zero / negative explicit sizes
+                Arguments.of(new int[]{2, 3}, new Object[]{0, 6}),
+                Arguments.of(new int[]{2, 3}, new Object[]{-2, 3}),
+                // input dims not strictly increasing (would suggest a transpose)
+                Arguments.of(new int[]{2, 3}, new Object[]{new int[]{1}, new int[]{0}}),
+                Arguments.of(new int[]{2, 3, 4}, new Object[]{new int[]{1, 0}, new int[]{2}}),
+                // duplicate input dim
+                Arguments.of(new int[]{2, 3}, new Object[]{new int[]{0, 0}}),
+                // input dim out of range
+                Arguments.of(new int[]{2, 3}, new Object[]{new int[]{5}}),
+                // input_dims placed such that the ravel would not align (implicit transpose)
+                Arguments.of(new int[]{2, 2, 2}, new Object[]{new int[]{2}, 4}),
+                // empty shape
+                Arguments.of(new int[]{2, 3}, new Object[]{})
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidReshapes")
+    public void testReshapeInvalidConfig(int[] inputShape, Object[] shape) throws ZarrException {
+        ReshapeCodec codec = reshapeCodec(shape, inputShape);
+        ucar.ma2.Array input = sequential(inputShape);
+        assertThrows(ZarrException.class, () -> codec.encode(input));
+    }
+
+    @Test
+    public void testEncodeRejectsWrongInputShape() throws ZarrException {
+        ReshapeCodec codec = reshapeCodec(new Object[]{new int[]{0, 1}}, new int[]{2, 3});
+        ucar.ma2.Array wrong = sequential(new int[]{3, 3});
+        assertThrows(ZarrException.class, () -> codec.encode(wrong));
+    }
+
+    @Test
+    public void testReshapeCodecReadWriteSingleChunk() throws ZarrException, IOException {
+        int[] shape = new int[]{4, 5, 6, 3};
+        int[] testData = new int[4 * 5 * 6 * 3];
+        Arrays.setAll(testData, p -> p);
+
+        StoreHandle storeHandle = new FilesystemStore(TESTOUTPUT).resolve("reshape_single_chunk");
+        ArrayMetadataBuilder builder = Array.metadataBuilder()
+                .withShape(4, 5, 6, 3)
+                .withDataType(DataType.UINT32)
+                .withChunkShape(4, 5, 6, 3)
+                .withFillValue(0)
+                .withCodecs(c -> c.withReshape(new Object[]{new int[]{0, 1}, new int[]{2}, 3}).withZstd());
+        Array writeArray = Array.create(storeHandle, builder.build());
+        writeArray.write(ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, shape, testData));
+
+        Array readArray = Array.open(storeHandle);
+        ucar.ma2.Array result = readArray.read();
+
+        Assertions.assertArrayEquals(testData, (int[]) result.get1DJavaArray(ucar.ma2.DataType.UINT));
+    }
+
+    @Test
+    public void testReshapeCodecReadWriteMultipleChunks() throws ZarrException, IOException {
+        int[] shape = new int[]{8, 6, 4};
+        int[] testData = new int[8 * 6 * 4];
+        Arrays.setAll(testData, p -> p);
+
+        StoreHandle storeHandle = new FilesystemStore(TESTOUTPUT).resolve("reshape_multi_chunk");
+        ArrayMetadataBuilder builder = Array.metadataBuilder()
+                .withShape(8, 6, 4)
+                .withDataType(DataType.UINT32)
+                .withChunkShape(4, 3, 4)
+                .withFillValue(0)
+                // Fold the 3D chunk into a 2D chunk, a typical image-codec preparation step.
+                .withCodecs(c -> c.withReshape(new Object[]{new int[]{0, 1}, new int[]{2}}).withBytes("LITTLE"));
+        Array writeArray = Array.create(storeHandle, builder.build());
+        writeArray.write(ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, shape, testData));
+
+        Array readArray = Array.open(storeHandle);
+        ucar.ma2.Array result = readArray.read();
+
+        Assertions.assertArrayEquals(testData, (int[]) result.get1DJavaArray(ucar.ma2.DataType.UINT));
+    }
+
+    @Test
+    public void testReshapeCombinedWithTranspose() throws ZarrException, IOException {
+        int[] shape = new int[]{4, 4, 4};
+        int[] testData = new int[4 * 4 * 4];
+        Arrays.setAll(testData, p -> p);
+
+        StoreHandle storeHandle = new FilesystemStore(TESTOUTPUT).resolve("reshape_with_transpose");
+        ArrayMetadataBuilder builder = Array.metadataBuilder()
+                .withShape(4, 4, 4)
+                .withDataType(DataType.UINT32)
+                .withChunkShape(4, 4, 4)
+                .withFillValue(0)
+                // transpose reorders, reshape then folds — the spec's intended combination.
+                .withCodecs(c -> c.withTranspose(new int[]{2, 1, 0})
+                        .withReshape(new Object[]{new int[]{0, 1}, new int[]{2}})
+                        .withBytes("LITTLE"));
+        Array writeArray = Array.create(storeHandle, builder.build());
+        writeArray.write(ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, shape, testData));
+
+        Array readArray = Array.open(storeHandle);
+        ucar.ma2.Array result = readArray.read();
+
+        Assertions.assertArrayEquals(testData, (int[]) result.get1DJavaArray(ucar.ma2.DataType.UINT));
+    }
+
+    @Test
+    public void testInvalidReshapeFailsOnWrite() {
+        StoreHandle storeHandle = new FilesystemStore(TESTOUTPUT).resolve("reshape_invalid_write");
+        ArrayMetadataBuilder builder = Array.metadataBuilder()
+                .withShape(4, 4)
+                .withDataType(DataType.UINT32)
+                .withChunkShape(4, 4)
+                .withFillValue(0)
+                // product 5 != 16
+                .withCodecs(c -> c.withReshape(new Object[]{5}).withBytes("LITTLE"));
+
+        assertThrows(ZarrException.class, () -> {
+            Array writeArray = Array.create(storeHandle, builder.build());
+            int[] testData = new int[16];
+            writeArray.write(ucar.ma2.Array.factory(ucar.ma2.DataType.UINT, new int[]{4, 4}, testData));
+        });
+    }
+}

--- a/src/test/java/dev/zarr/zarrjava/ReshapeCodecTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ReshapeCodecTest.java
@@ -88,7 +88,7 @@ public class ReshapeCodecTest extends ZarrTest {
         // decode is the inverse of encode.
         ucar.ma2.Array decoded = codec.decode(encoded);
         Assertions.assertArrayEquals(inputShape, decoded.getShape());
-        assert MAMath.equals(input, decoded);
+        Assertions.assertTrue(MAMath.equals(input, decoded));
     }
 
     @Test


### PR DESCRIPTION
Implemented a spec-compliant ReshapeCodec https://github.com/zarr-developers/zarr-extensions/pull/10 in zarr-java plus tests, all passing.

- Codec: array→array reshape preserving C-order ravel; validates all spec rules (input_dims, -1, product invariant, strictly-increasing dims, alignment). 
- Tests: round-trips (merge/split/flatten/singletons/-1/high-dim→1D), metadata resolution, ~11 invalid-config edge cases, and end-to-end read/write (incl. combined with transpose).
