### PR TITLE
Test infrastructure: detect missing data types, enum not written out manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,23 @@ jobs:
       - name: Build
         run: mvn compile
 
+      # Runs both test tiers. The 'interop' tag is excluded from a bare `mvn test` so a
+      # contributor without a working uv/zarr-python setup can still run the suite locally;
+      # CI has Python, so it clears the exclusion and runs everything.
+      #
+      # Interop belongs on the pull-request path, not on a schedule: it catches bugs caused by
+      # the change under review -- a dtype or codec where zarr-java's reader and writer agree
+      # with each other but not with anyone else -- and that is feedback you want on the PR.
+      # It costs about 20s now that zarr-python runs as one worker process instead of one
+      # interpreter launch per test case.
       - name: Test
         env:
           MAVEN_OPTS: "-Xmx6g"
         run: |
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            mvn --no-transfer-progress test -DargLine="-Xmx6g" -DrunS3Tests=true
+            mvn --no-transfer-progress test -DargLine="-Xmx6g" -DrunS3Tests=true -DexcludedTestGroups=
           else
-            mvn --no-transfer-progress test -DargLine="-Xmx6g"
+            mvn --no-transfer-progress test -DargLine="-Xmx6g" -DexcludedTestGroups=
           fi
       - name: Assemble JAR
         run: mvn package -DskipTests

--- a/.github/workflows/data-type-drift.yml
+++ b/.github/workflows/data-type-drift.yml
@@ -1,0 +1,105 @@
+# Keeps src/test/resources/spec-data-types-v3.json honest.
+#
+# That file is the external conformance list DataTypeConformanceTest checks zarr-java against.
+# It is generated from zarr-python's data type registry and committed, so the Java test stays
+# offline and fast. Committing it buys reproducibility -- a given commit always tests against a
+# known list -- at the cost of the list going stale. These two jobs pay that cost back.
+#
+# The split follows who caused the breakage:
+#
+#   stale-check     runs per pull request. Fails when the committed list disagrees with the
+#                   zarr-python version this repository pins. That is caused by the change under
+#                   review (a dependency bump without a regeneration, or a hand-edited file), so
+#                   it belongs on the pull-request path.
+#
+#   upstream-drift  runs nightly. Fails when the *latest* zarr-python knows a data type our
+#                   pinned version did not. No pull request caused that, so gating pull requests
+#                   on it would fail innocent changes for reasons their authors cannot act on.
+#                   As a scheduled job it becomes a task someone picks up: bump the pin,
+#                   regenerate, and either implement the new data type or add it to
+#                   KNOWN_UNSUPPORTED with a note.
+
+name: Data Type Conformance List
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+  schedule:
+    # 04:23 UTC daily. Off the hour so it does not queue behind everyone else's midnight cron.
+    - cron: '23 4 * * *'
+
+jobs:
+  stale-check:
+    name: Committed list matches the pinned zarr-python
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      # Pinned explicitly: uv.lock resolves zarr differently per Python version, so letting uv
+      # pick an interpreter would make this check depend on what happens to be installed. 3.11 is
+      # what the committed list was generated with and what ci.yml runs the interop tier on.
+      - name: Regenerate the conformance list
+        run: uv run --python 3.11 src/test/python-scripts/generate_spec_data_types.py
+
+      - name: Fail if it differs from the committed copy
+        run: |
+          if ! git diff --exit-code src/test/resources/spec-data-types-v3.json; then
+            echo
+            echo "::error::spec-data-types-v3.json is out of date with the pinned zarr-python."
+            echo "Regenerate and commit it:"
+            echo "    uv run src/test/python-scripts/generate_spec_data_types.py"
+            echo "If the diff adds a data type, either implement it in dev.zarr.zarrjava.v3.DataType"
+            echo "or add it to DataTypeConformanceTest.KNOWN_UNSUPPORTED with a note on what it needs."
+            exit 1
+          fi
+
+  upstream-drift:
+    name: Latest zarr-python has no data types we have not seen
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      # `uv run` alone would reuse uv.lock and regenerate a byte-identical file forever, which
+      # would make this job pass vacuously. Re-resolving zarr is the entire point: it is how a
+      # new upstream data type reaches us.
+      - name: Resolve the latest zarr-python
+        run: |
+          uv lock --upgrade-package zarr
+          uv run --python 3.11 python -c "import zarr; print('resolved zarr-python', zarr.__version__)"
+
+      - name: Regenerate the conformance list against it
+        run: uv run --python 3.11 src/test/python-scripts/generate_spec_data_types.py
+
+      - name: Report drift
+        run: |
+          if ! git diff --exit-code src/test/resources/spec-data-types-v3.json; then
+            echo
+            echo "::warning::A newer zarr-python describes data types differently than our pinned version."
+            echo "This is not a broken build -- it is a to-do. To act on it:"
+            echo "  1. bump the zarr pin in pyproject.toml and commit the updated uv.lock"
+            echo "  2. uv run src/test/python-scripts/generate_spec_data_types.py"
+            echo "  3. implement any new data type, or list it in KNOWN_UNSUPPORTED with a note"
+            exit 1
+          fi
+          echo "No drift: the latest zarr-python matches the committed conformance list."

--- a/README.md
+++ b/README.md
@@ -60,7 +60,36 @@ data
 
 ### Run Tests Locally
 
-To be able to run the tests locally, make sure to have `python3.11` and `uv` installed.
+The test suite is split into two tiers.
+
+**Fast tier (default).** Offline, no Python required, runs in seconds. This is what every pull
+request should run:
+
+```
+mvn test
+```
+
+It covers the metadata-only data type conformance checks, per-data-type round-trips, and the
+committed golden fixtures.
+
+**Interop tier.** Cross-checks zarr-java against zarr-python, and needs `python3.11` and `uv`
+installed. Tagged `interop` and excluded from the default run; enable it by clearing the excluded
+groups:
+
+```
+mvn test -DexcludedTestGroups=            # everything, both tiers
+mvn test -DexcludedTestGroups= -Dtest=ZarrPythonTests   # just the interop tier
+```
+
+These tests matter more than their tag suggests, so the intent is for a nightly job to run them
+rather than for anyone to skip them indefinitely. A test that writes with zarr-java and reads back
+with zarr-java passes even when the reader and writer share the same misunderstanding of the spec —
+the resulting store is then wrong for every other tool, and only a second implementation can catch
+it.
+
+zarr-python runs as one long-lived worker process for the whole suite (see `ZarrPythonWorker` and
+`src/test/python-scripts/zarr_python_worker.py`) instead of one `uv run` per test case. Interpreter
+startup used to dominate the interop tier; batching it took the full interop run from ~129s to ~19s.
 
 Furthermore, you will need the `l4_sample` test data:
 
@@ -68,6 +97,25 @@ Furthermore, you will need the `l4_sample` test data:
 && cd testdata
 && unzip l4_sample.zip
 `
+
+### Data Type Coverage
+
+`DataTypeConformanceTest` checks zarr-java's data types against an external list
+(`src/test/resources/spec-data-types-v3.json`, generated from zarr-python's registry). Data types we
+do not implement yet are enumerated in that test's `KNOWN_UNSUPPORTED` set.
+
+The list is deliberately *not* derived from our own `DataType` enum. A provider built from the enum
+can only assert that what we implemented is implemented, so a data type we never added stays
+invisible and no test can fail for it — which is how `float16` and `string` went unnoticed.
+
+Implementing a data type therefore means deleting its entry from `KNOWN_UNSUPPORTED`; the assertion
+is bidirectional, so leaving a stale entry there fails the build too.
+
+To refresh the list after a zarr-python upgrade:
+
+```
+uv run src/test/python-scripts/generate_spec_data_types.py
+```
 
 ### Code Style & Formatting
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ data
 
 The test suite is split into two tiers.
 
-**Fast tier (default).** Offline, no Python required, runs in seconds. This is what every pull
-request should run:
+**Fast tier (default).** Offline, no Python required, runs in seconds:
 
 ```
 mvn test
@@ -73,23 +72,24 @@ It covers the metadata-only data type conformance checks, per-data-type round-tr
 committed golden fixtures.
 
 **Interop tier.** Cross-checks zarr-java against zarr-python, and needs `python3.11` and `uv`
-installed. Tagged `interop` and excluded from the default run; enable it by clearing the excluded
-groups:
+installed. It is tagged `interop` and excluded from a bare `mvn test`, so that a contributor
+without a working Python setup still gets a useful run. Clear the exclusion to include it:
 
 ```
-mvn test -DexcludedTestGroups=            # everything, both tiers
+mvn test -DexcludedTestGroups=                          # everything, both tiers
 mvn test -DexcludedTestGroups= -Dtest=ZarrPythonTests   # just the interop tier
 ```
 
-These tests matter more than their tag suggests, so the intent is for a nightly job to run them
-rather than for anyone to skip them indefinitely. A test that writes with zarr-java and reads back
-with zarr-java passes even when the reader and writer share the same misunderstanding of the spec —
-the resulting store is then wrong for every other tool, and only a second implementation can catch
-it.
+**CI runs both tiers on every pull request** — the tag exists for local convenience, not to keep
+these tests out of the build. They belong on the pull-request path because they catch bugs caused
+by the change under review: a test that writes with zarr-java and reads back with zarr-java passes
+even when the reader and writer share the same misunderstanding of the spec. The resulting store is
+then wrong for every other tool, and only a second implementation can catch that.
 
-zarr-python runs as one long-lived worker process for the whole suite (see `ZarrPythonWorker` and
-`src/test/python-scripts/zarr_python_worker.py`) instead of one `uv run` per test case. Interpreter
-startup used to dominate the interop tier; batching it took the full interop run from ~129s to ~19s.
+The interop tier is cheap enough for that. zarr-python runs as one long-lived worker process for
+the whole suite (see `ZarrPythonWorker` and `src/test/python-scripts/zarr_python_worker.py`) rather
+than one `uv run` per test case; interpreter startup used to dominate, and removing it took the
+full interop run from ~129s to ~19s.
 
 Furthermore, you will need the `l4_sample` test data:
 
@@ -116,6 +116,14 @@ To refresh the list after a zarr-python upgrade:
 ```
 uv run src/test/python-scripts/generate_spec_data_types.py
 ```
+
+Two CI jobs keep it from silently rotting (`.github/workflows/data-type-drift.yml`), split by who
+caused the problem. On every pull request, the list is regenerated against the pinned zarr-python
+and the build fails if it differs — that catches a dependency bump without a regeneration. Nightly,
+it is regenerated against the *latest* zarr-python instead, which is how a newly specified data
+type reaches us. The nightly check is deliberately not a pull-request gate: no pull request causes
+upstream to release a version, and failing unrelated changes for it only teaches people to ignore
+a red build.
 
 ### Code Style & Formatting
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
     <properties>
         <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+          JUnit tags excluded from the default test run. Override to run everything:
+            mvn test -DexcludedTestGroups=
+        -->
+        <excludedTestGroups>interop</excludedTestGroups>
         <jackson.version>2.20.0</jackson.version>
         <aws.version>2.34.6</aws.version>
         <netcdfJavaVersion>5.9.1</netcdfJavaVersion>
@@ -156,6 +161,21 @@
                 <version>3.2.5</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <!--
+                      Tests are split into two tiers.
+
+                      The default run is fast and fully offline: metadata conformance checks,
+                      per-data-type round-trips and the committed golden fixtures. It needs no
+                      Python, so a contributor without a working uv/zarr-python setup can still
+                      run it, and it is quick enough for every pull request.
+
+                      The 'interop' tier drives zarr-python for cross-implementation checks. It
+                      is excluded here and enabled with -DexcludedGroups= (see the README), which
+                      is what the nightly job does. Excluding it by default is a deliberate
+                      trade-off: interop tests catch bugs that no self-round-trip test can, so
+                      they must keep running, just not on the critical path of every push.
+                    -->
+                    <excludedGroups>${excludedTestGroups}</excludedGroups>
                     <environmentVariables>
                         <!-- Force Testcontainers to use a newer Docker API version supported by your local Daemon -->
                         <DOCKER_API_VERSION>1.44</DOCKER_API_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -167,13 +167,14 @@
                       The default run is fast and fully offline: metadata conformance checks,
                       per-data-type round-trips and the committed golden fixtures. It needs no
                       Python, so a contributor without a working uv/zarr-python setup can still
-                      run it, and it is quick enough for every pull request.
+                      run it and get a useful result.
 
-                      The 'interop' tier drives zarr-python for cross-implementation checks. It
-                      is excluded here and enabled with -DexcludedGroups= (see the README), which
-                      is what the nightly job does. Excluding it by default is a deliberate
-                      trade-off: interop tests catch bugs that no self-round-trip test can, so
-                      they must keep running, just not on the critical path of every push.
+                      The 'interop' tier drives zarr-python for cross-implementation checks. It is
+                      excluded here purely as a local convenience. CI has Python and clears the
+                      exclusion with -DexcludedTestGroups=, so both tiers run on every pull
+                      request. Interop tests catch bugs no self-round-trip test can, and now that
+                      zarr-python runs as a single worker process they cost about 20s, so there is
+                      no reason to keep them off the pull-request path.
                     -->
                     <excludedGroups>${excludedTestGroups}</excludedGroups>
                     <environmentVariables>

--- a/src/test/java/dev/zarr/zarrjava/DataTypeConformanceTest.java
+++ b/src/test/java/dev/zarr/zarrjava/DataTypeConformanceTest.java
@@ -1,0 +1,242 @@
+package dev.zarr.zarrjava;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.zarr.zarrjava.v3.ArrayMetadata;
+import dev.zarr.zarrjava.v3.DataType;
+import dev.zarr.zarrjava.v3.Node;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Metadata-only conformance tests for Zarr v3 data types.
+ *
+ * <p>These tests exist because the rest of the suite cannot detect a data type we never
+ * implemented. Providers such as {@link ZarrTest#dataTypeProviderV3()} enumerate our own
+ * {@link DataType} enum, so they can only ever assert that what we implemented is implemented -- a
+ * missing data type is invisible by construction, and no test can fail for an enum constant that
+ * does not exist. That blind spot is how {@code float16} and {@code string} went unnoticed.
+ *
+ * <p>The fix is to drive coverage from an <em>external</em> list: {@code
+ * /spec-data-types-v3.json}, generated from zarr-python's data type registry by {@code
+ * src/test/python-scripts/generate_spec_data_types.py} and committed so these tests stay offline
+ * and fast. Every entry must either parse or be named in {@link #KNOWN_UNSUPPORTED}.
+ *
+ * <p>The central assertion is deliberately bidirectional. An entry that fails to parse and is not
+ * listed is a coverage gap; an entry that parses but is still listed means the list went stale.
+ * Implementing a data type therefore shows up as a one-line deletion from {@link
+ * #KNOWN_UNSUPPORTED}, and forgetting to delete it is itself a test failure.
+ *
+ * <p>No I/O, no compression, no Python: these run in milliseconds and belong in every pull-request
+ * build.
+ */
+public class DataTypeConformanceTest {
+
+    private static final String RESOURCE = "/spec-data-types-v3.json";
+
+    /**
+     * Data types that a reference implementation supports and zarr-java does not.
+     *
+     * <p>This list is the honest inventory of our gaps. It is expected to shrink, never grow: each
+     * entry removed is a data type gained. Keeping the gaps enumerated here rather than merely
+     * absent is the whole point -- an unimplemented data type is now a visible, deliberate decision
+     * instead of a silent hole.
+     *
+     * <p>Grouped by the work each needs:
+     *
+     * <ul>
+     *   <li><b>Fixed itemsize</b> -- {@code float16}, {@code complex64}, {@code complex128},
+     *       {@code fixed_length_utf32}, {@code raw_bytes}, {@code null_terminated_bytes}. Additive:
+     *       these need an enum entry, an in-memory representation, and fill-value rules. The
+     *       existing {@code bytes} codec already serializes them; no new codec is required.
+     *       {@code ucar.ma2} has no half-float and no complex type, so the open question is how to
+     *       represent them in memory, not how to encode them.
+     *   <li><b>Variable itemsize</b> -- {@code string}, {@code variable_length_bytes}. These
+     *       require a dedicated array-to-bytes codec ({@code vlen-utf8} / {@code vlen-bytes})
+     *       because there is no itemsize to compute offsets from, which means breaking the
+     *       fixed-size assumption in {@code core.DataType#getByteCount()}.
+     *   <li><b>Compound / parameterized</b> -- {@code structured}, {@code numpy.datetime64},
+     *       {@code numpy.timedelta64}. Note that zarr-python itself warns that {@code structured}
+     *       and {@code variable_length_bytes} have no stable Zarr v3 specification yet.
+     * </ul>
+     */
+    static final Set<String> KNOWN_UNSUPPORTED = Collections.unmodifiableSet(
+            new LinkedHashSet<>(Arrays.asList(
+                    "float16",
+                    "complex64",
+                    "complex128",
+                    "fixed_length_utf32",
+                    "string",
+                    "raw_bytes",
+                    "null_terminated_bytes",
+                    "variable_length_bytes",
+                    "structured",
+                    "numpy.datetime64",
+                    "numpy.timedelta64"
+            )));
+
+    private static JsonNode loadSpecDocument() {
+        try (InputStream in = DataTypeConformanceTest.class.getResourceAsStream(RESOURCE)) {
+            Assertions.assertNotNull(in, "Missing test resource " + RESOURCE
+                    + ". Regenerate it with 'uv run src/test/python-scripts/generate_spec_data_types.py'.");
+            return new ObjectMapper().readTree(in);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not read " + RESOURCE, e);
+        }
+    }
+
+    static Stream<Arguments> specDataTypes() {
+        JsonNode dataTypes = loadSpecDocument().get("data_types");
+        Stream.Builder<Arguments> builder = Stream.builder();
+        for (JsonNode entry : dataTypes) {
+            builder.add(Arguments.of(
+                    entry.get("name").asText(),
+                    entry.get("data_type"),
+                    entry.get("fill_value")
+            ));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Builds the smallest {@code zarr.json} that exercises a data type, so a parse failure can only
+     * be about the data type or its fill value.
+     */
+    private static String minimalArrayMetadata(JsonNode dataType, JsonNode fillValue) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("zarr_format", 3);
+        root.put("node_type", "array");
+        ArrayNode shape = root.putArray("shape");
+        shape.add(4);
+        root.set("data_type", dataType);
+        ObjectNode chunkGrid = root.putObject("chunk_grid");
+        chunkGrid.put("name", "regular");
+        chunkGrid.putObject("configuration").putArray("chunk_shape").add(2);
+        root.putObject("chunk_key_encoding").put("name", "default");
+        root.set("fill_value", fillValue);
+        root.putArray("codecs").addObject().put("name", "bytes");
+        return root.toString();
+    }
+
+    /**
+     * Every data type a reference implementation writes must either be understood by zarr-java or be
+     * an acknowledged gap.
+     *
+     * <p>Deserializes the {@code data_type} member alone rather than a whole metadata document, so
+     * the result reflects data type support specifically and cannot be perturbed by unrelated
+     * validation elsewhere in {@link ArrayMetadata} (codec/data type compatibility checks, for
+     * instance).
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("specDataTypes")
+    public void specDataTypeIsSupportedOrKnownUnsupported(String name, JsonNode dataTypeJson,
+                                                          JsonNode fillValueJson) {
+        boolean parsed;
+        String failure = null;
+        try {
+            DataType parsedDataType =
+                    Node.makeObjectMapper().treeToValue(dataTypeJson, DataType.class);
+            parsed = parsedDataType != null;
+        } catch (Exception e) {
+            parsed = false;
+            failure = e.getClass().getSimpleName() + ": " + e.getMessage();
+        }
+
+        boolean listedAsUnsupported = KNOWN_UNSUPPORTED.contains(name);
+
+        if (parsed && listedAsUnsupported) {
+            Assertions.fail("Data type '" + name + "' now parses, but is still listed in "
+                    + "KNOWN_UNSUPPORTED. Remove it from that list -- implementing a data type is "
+                    + "meant to show up as a deletion there.");
+        }
+        if (!parsed && !listedAsUnsupported) {
+            Assertions.fail("Data type '" + name + "' is supported by the reference implementation "
+                    + "but zarr-java cannot parse it: " + failure
+                    + "\nEither implement it in dev.zarr.zarrjava.v3.DataType or add it to "
+                    + "KNOWN_UNSUPPORTED with a note on what it needs.");
+        }
+    }
+
+    /**
+     * For the data types we do support, the fill value a reference implementation writes must parse
+     * as part of a complete metadata document.
+     *
+     * <p>Skipped for acknowledged gaps -- those already fail the test above, and reporting the same
+     * gap twice would only obscure it.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("specDataTypes")
+    public void specFillValueParsesForSupportedDataType(String name, JsonNode dataTypeJson,
+                                                        JsonNode fillValueJson) throws Exception {
+        Assumptions.assumeFalse(KNOWN_UNSUPPORTED.contains(name),
+                "data type not supported yet: " + name);
+
+        String json = minimalArrayMetadata(dataTypeJson, fillValueJson);
+        ArrayMetadata metadata = Node.makeObjectMapper().readValue(json, ArrayMetadata.class);
+
+        Assertions.assertNotNull(metadata.dataType,
+                "Parsed metadata for '" + name + "' has no data type");
+        Assertions.assertNotNull(metadata.parsedFillValue,
+                "Fill value " + fillValueJson + " for '" + name + "' parsed to null");
+    }
+
+    /**
+     * Guards the conformance list itself: a resource that failed to load, or that lost entries in a
+     * regeneration, would otherwise make the tests above pass vacuously.
+     */
+    @Test
+    public void specDataTypeListIsPresentAndPlausible() {
+        JsonNode document = loadSpecDocument();
+        JsonNode dataTypes = document.get("data_types");
+        Assertions.assertNotNull(dataTypes, "Conformance list has no 'data_types' member");
+        Assertions.assertTrue(dataTypes.size() >= 22,
+                "Expected at least the 22 data types zarr-python 3.1.6 supports, found "
+                        + dataTypes.size() + ". Was " + RESOURCE + " regenerated correctly?");
+
+        Set<String> names = new HashSet<>();
+        for (JsonNode entry : dataTypes) {
+            names.add(entry.get("name").asText());
+        }
+        Assertions.assertTrue(names.containsAll(KNOWN_UNSUPPORTED),
+                "KNOWN_UNSUPPORTED names missing from " + RESOURCE + ": "
+                        + KNOWN_UNSUPPORTED.stream().filter(n -> !names.contains(n)).toArray());
+    }
+
+    /**
+     * Documents the gap as a single number, so a reviewer sees at a glance how much of a reference
+     * implementation's data type surface we cover. Update the expected count when the list shrinks.
+     */
+    @Test
+    public void supportedDataTypeCountIsAsExpected() {
+        JsonNode dataTypes = loadSpecDocument().get("data_types");
+        int total = dataTypes.size();
+        int unsupported = 0;
+        for (JsonNode entry : dataTypes) {
+            if (KNOWN_UNSUPPORTED.contains(entry.get("name").asText())) {
+                unsupported++;
+            }
+        }
+        Assertions.assertEquals(KNOWN_UNSUPPORTED.size(), unsupported,
+                "Every KNOWN_UNSUPPORTED entry should appear in the conformance list");
+        Assertions.assertEquals(DataType.values().length, total - unsupported,
+                "Number of data types the conformance list says we support should match the "
+                        + "DataType enum. If these diverge, either the enum gained a data type that "
+                        + "is not in the conformance list, or KNOWN_UNSUPPORTED is stale.");
+    }
+}

--- a/src/test/java/dev/zarr/zarrjava/ZarrPythonTests.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrPythonTests.java
@@ -12,6 +12,7 @@ import dev.zarr.zarrjava.v3.DataType;
 import dev.zarr.zarrjava.v3.codec.CodecBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -22,15 +23,30 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
 
+/**
+ * Cross-implementation tests: everything here checks zarr-java against zarr-python.
+ *
+ * <p>These are the only tests that need Python, and they are tagged {@code interop} so the
+ * pull-request build can skip them. That split matters because an interop failure is usually a real
+ * format bug worth investigating slowly, while the fast offline tiers -- {@link
+ * DataTypeConformanceTest}, the per-data-type round-trips in {@link ZarrV3Test} and {@link
+ * ZarrV2Test}, and the committed golden fixtures -- give quick feedback on every change. See the
+ * "Running the tests" section of the README.
+ *
+ * <p>An external reference implementation is not optional for a format library. A test that writes
+ * with zarr-java and reads it back with zarr-java passes even when reader and writer share the same
+ * misunderstanding of the spec, and the resulting store is wrong for every other tool. Only a second
+ * implementation can catch that.
+ *
+ * <p>zarr-python runs as a single long-lived process ({@link ZarrPythonWorker}) rather than one
+ * launch per test case; see that class for why.
+ */
+@Tag("interop")
 public class ZarrPythonTests extends ZarrTest {
-
-    final static Path PYTHON_TEST_PATH = Paths.get("src/test/python-scripts/");
 
     public static int runCommand(String... command) throws IOException, InterruptedException {
         ProcessBuilder pb = new ProcessBuilder();
@@ -114,17 +130,23 @@ public class ZarrPythonTests extends ZarrTest {
         return Stream.concat(datatypeTests, bloscTests);
     }
 
-    public void run_python_script(String scriptName, String... args) throws IOException, InterruptedException {
-        int exitCode = runCommand(Stream.concat(Stream.of("uv", "run", PYTHON_TEST_PATH.resolve(scriptName)
-                .toString()), Arrays.stream(args)).toArray(String[]::new));
-        assert exitCode == 0;
+    /**
+     * Runs one zarr-python operation in the shared worker process.
+     *
+     * <p>Replaces the previous one-{@code uv run}-per-call approach. The operation names map to the
+     * functions in {@code src/test/python-scripts/zarr_fixtures.py}, which the standalone CLI
+     * scripts also call -- so driving an operation from here and running the matching script by hand
+     * execute the same code.
+     */
+    public void runPython(String op, String... args) throws IOException, InterruptedException {
+        ZarrPythonWorker.get().call(op, args);
     }
 
     @ParameterizedTest
     @MethodSource("compressorAndDataTypeProviderV3")
     public void testReadV3(String codec, String codecParam, DataType dataType) throws IOException, ZarrException, InterruptedException {
         StoreHandle storeHandle = new FilesystemStore(TESTOUTPUT).resolve("testReadV3", codec, codecParam, dataType.name());
-        run_python_script("zarr_python_write.py", codec, codecParam, dataType.name().toLowerCase(), storeHandle.toPath().toString());
+        runPython("write_v3", codec, codecParam, dataType.name().toLowerCase(), storeHandle.toPath().toString());
         Array array = Array.open(storeHandle);
         ucar.ma2.Array result = array.read();
 
@@ -199,14 +221,14 @@ public class ZarrPythonTests extends ZarrTest {
         assertIsTestdata(result, dataType);
 
         //read in zarr_python
-        run_python_script("zarr_python_read.py", codec, codecParam, dataType.name().toLowerCase(), storeHandle.toPath().toString());
+        runPython("read_v3", codec, codecParam, dataType.name().toLowerCase(), storeHandle.toPath().toString());
     }
 
     @ParameterizedTest
     @MethodSource("compressorAndDataTypeProviderV2")
     public void testReadV2(String compressor, String compressorParam, dev.zarr.zarrjava.v2.DataType dt) throws IOException, ZarrException, InterruptedException {
         StoreHandle storeHandle = new FilesystemStore(TESTOUTPUT).resolve("testReadV2", compressor, compressorParam, dt.name());
-        run_python_script("zarr_python_write_v2.py", compressor, compressorParam, dt.getValue(), storeHandle.toPath().toString());
+        runPython("write_v2", compressor, compressorParam, dt.getValue(), storeHandle.toPath().toString());
 
         dev.zarr.zarrjava.v2.Array array = dev.zarr.zarrjava.v2.Array.open(storeHandle);
         ucar.ma2.Array result = array.read();
@@ -265,7 +287,7 @@ public class ZarrPythonTests extends ZarrTest {
         assertIsTestdata(result, dt);
 
         //read in zarr_python
-        run_python_script("zarr_python_read_v2.py", compressor, compressorParam, dt.getValue(), storeHandle.toPath().toString());
+        runPython("read_v2", compressor, compressorParam, dt.getValue(), storeHandle.toPath().toString());
     }
 
     @CsvSource({"0,true", "0,false", "5, true", "10, false"})
@@ -292,14 +314,7 @@ public class ZarrPythonTests extends ZarrTest {
         }
 
         //decompress in python
-        int exitCode = ZarrPythonTests.runCommand(
-                "uv",
-                "run",
-                PYTHON_TEST_PATH.resolve("zstd_decompress.py").toString(),
-                compressedDataPath,
-                Integer.toString(number)
-        );
-        assert exitCode == 0;
+        runPython("zstd_decompress", compressedDataPath, Integer.toString(number));
     }
 
     @Test
@@ -316,7 +331,7 @@ public class ZarrPythonTests extends ZarrTest {
 
         array.write(testdata(dataType));
 
-        run_python_script("zarr_python_group.py", storeHandle.toPath().toString(), storeHandle2.toPath().toString(), "" + 2);
+        runPython("group", storeHandle.toPath().toString(), storeHandle2.toPath().toString(), "" + 2);
 
         Group group2 = Group.open(storeHandle2);
         Assertions.assertEquals("value", group2.metadata().attributes().get("attr"));
@@ -343,7 +358,7 @@ public class ZarrPythonTests extends ZarrTest {
 
         array.write(testdata(dataType));
 
-        run_python_script("zarr_python_group.py", storeHandle.toPath().toString(), storeHandle2.toPath().toString(), "" + 3);
+        runPython("group", storeHandle.toPath().toString(), storeHandle2.toPath().toString(), "" + 3);
 
         dev.zarr.zarrjava.v3.Group group2 = dev.zarr.zarrjava.v3.Group.open(storeHandle2);
         Assertions.assertEquals("value", group2.metadata().attributes().get("attr"));

--- a/src/test/java/dev/zarr/zarrjava/ZarrPythonTests.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrPythonTests.java
@@ -30,12 +30,12 @@ import java.util.stream.Stream;
 /**
  * Cross-implementation tests: everything here checks zarr-java against zarr-python.
  *
- * <p>These are the only tests that need Python, and they are tagged {@code interop} so the
- * pull-request build can skip them. That split matters because an interop failure is usually a real
- * format bug worth investigating slowly, while the fast offline tiers -- {@link
- * DataTypeConformanceTest}, the per-data-type round-trips in {@link ZarrV3Test} and {@link
- * ZarrV2Test}, and the committed golden fixtures -- give quick feedback on every change. See the
- * "Running the tests" section of the README.
+ * <p>These are the only tests that need Python, and they are tagged {@code interop} so that a bare
+ * {@code mvn test} skips them -- a contributor without a working uv/zarr-python setup still gets a
+ * useful run from the fast offline tiers ({@link DataTypeConformanceTest}, the per-data-type
+ * round-trips in {@link ZarrV3Test} and {@link ZarrV2Test}, and the committed golden fixtures).
+ * The tag is a local convenience only: CI clears the exclusion, so these run on every pull request.
+ * See the "Run Tests Locally" section of the README.
  *
  * <p>An external reference implementation is not optional for a format library. A test that writes
  * with zarr-java and reads it back with zarr-java passes even when reader and writer share the same

--- a/src/test/java/dev/zarr/zarrjava/ZarrPythonWorker.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrPythonWorker.java
@@ -1,0 +1,183 @@
+package dev.zarr.zarrjava;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A single long-lived zarr-python process, shared by every interop test in the JVM.
+ *
+ * <p>The interop suite used to run one {@code uv run <script>} per test case. Each launch started an
+ * interpreter and imported zarr and numpy, and that startup -- not the work -- dominated the suite:
+ * the test arrays are 16x16x16, about 16 KB, and cost nothing to encode. With roughly 78 v3 cases
+ * and 58 v2 cases, each invoking Python once, the suite spent minutes doing nothing but starting
+ * Python.
+ *
+ * <p>This class starts the interpreter once and talks to it over stdin/stdout using one JSON object
+ * per line (see {@code src/test/python-scripts/zarr_python_worker.py}). Per-test semantics are
+ * unchanged: every test still makes its own call and asserts on its own result, so a zarr-python
+ * failure is still reported against the test that caused it. That is why this is a worker rather
+ * than a "generate all fixtures in setup" batch step -- the batch approach would have collapsed
+ * many independent checks into one setup failure.
+ *
+ * <p>The process is started lazily on first use and shut down by a JVM shutdown hook.
+ */
+final class ZarrPythonWorker {
+
+    private static final Path PYTHON_TEST_PATH = Paths.get("src/test/python-scripts/");
+    private static final String WORKER_SCRIPT = "zarr_python_worker.py";
+
+    /** Generous: covers a cold uv environment resolve on the very first call. */
+    private static final long STARTUP_TIMEOUT_SECONDS = 300;
+    /** Any single fixture operation is milliseconds of real work; this only catches a hang. */
+    private static final long CALL_TIMEOUT_SECONDS = 300;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static ZarrPythonWorker instance;
+
+    private final Process process;
+    private final BufferedWriter stdin;
+    private final BlockingQueue<String> responses = new LinkedBlockingQueue<>();
+    private final List<String> stderrLines = new ArrayList<>();
+
+    private ZarrPythonWorker() throws IOException, InterruptedException {
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                "uv", "run", PYTHON_TEST_PATH.resolve(WORKER_SCRIPT).toString());
+        this.process = processBuilder.start();
+        this.stdin = new BufferedWriter(
+                new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
+
+        startPump(new BufferedReader(
+                        new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8)),
+                "zarr-python-worker-stdout", responses::add);
+
+        startPump(new BufferedReader(
+                        new InputStreamReader(process.getErrorStream(), StandardCharsets.UTF_8)),
+                "zarr-python-worker-stderr", line -> {
+                    synchronized (stderrLines) {
+                        stderrLines.add(line);
+                    }
+                    System.err.println("[zarr-python] " + line);
+                });
+
+        handshake();
+    }
+
+    private void startPump(BufferedReader reader, String threadName, LineSink sink) {
+        Thread thread = new Thread(() -> {
+            try {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    sink.accept(line);
+                }
+            } catch (IOException ignored) {
+                // Process exited; nothing useful left to read.
+            }
+        }, threadName);
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private void handshake() throws IOException, InterruptedException {
+        ObjectNode request = OBJECT_MAPPER.createObjectNode();
+        request.put("op", "ping");
+        send(request);
+
+        String line = responses.poll(STARTUP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (line == null) {
+            throw new IllegalStateException(
+                    "zarr-python worker did not become ready within " + STARTUP_TIMEOUT_SECONDS
+                            + "s. Is 'uv' installed and on PATH?\n" + collectedStderr());
+        }
+    }
+
+    /**
+     * Returns the shared worker, starting it if necessary.
+     *
+     * <p>Synchronized on the class so parallel test execution cannot start two interpreters.
+     */
+    static synchronized ZarrPythonWorker get() throws IOException, InterruptedException {
+        if (instance == null || !instance.process.isAlive()) {
+            instance = new ZarrPythonWorker();
+            Runtime.getRuntime().addShutdownHook(new Thread(ZarrPythonWorker::shutdown));
+        }
+        return instance;
+    }
+
+    private static synchronized void shutdown() {
+        if (instance == null) {
+            return;
+        }
+        try {
+            ObjectNode request = OBJECT_MAPPER.createObjectNode();
+            request.put("op", "shutdown");
+            instance.send(request);
+            instance.process.waitFor(10, TimeUnit.SECONDS);
+        } catch (IOException | InterruptedException ignored) {
+            // Best effort; the process is killed below either way.
+        } finally {
+            instance.process.destroy();
+            instance = null;
+        }
+    }
+
+    private void send(ObjectNode request) throws IOException {
+        stdin.write(OBJECT_MAPPER.writeValueAsString(request));
+        stdin.write("\n");
+        stdin.flush();
+    }
+
+    private String collectedStderr() {
+        synchronized (stderrLines) {
+            return String.join("\n", stderrLines);
+        }
+    }
+
+    /**
+     * Runs one zarr-python operation, failing the calling test if zarr-python reports a problem.
+     *
+     * @param op   operation name, as registered in {@code zarr_fixtures.OPERATIONS}
+     * @param args positional arguments for that operation
+     */
+    synchronized void call(String op, String... args) throws IOException, InterruptedException {
+        ObjectNode request = OBJECT_MAPPER.createObjectNode();
+        request.put("op", op);
+        ArrayNode argsNode = request.putArray("args");
+        for (String arg : args) {
+            argsNode.add(arg);
+        }
+        send(request);
+
+        String line = responses.poll(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (line == null) {
+            throw new IllegalStateException("zarr-python worker did not respond to '" + op
+                    + "' within " + CALL_TIMEOUT_SECONDS + "s.\n" + collectedStderr());
+        }
+
+        JsonNode response = OBJECT_MAPPER.readTree(line);
+        if (!response.path("ok").asBoolean(false)) {
+            throw new AssertionError("zarr-python '" + op + "' failed:\n"
+                    + response.path("error").asText("(no error detail)"));
+        }
+    }
+
+    private interface LineSink {
+        void accept(String line);
+    }
+}

--- a/src/test/java/dev/zarr/zarrjava/ZarrTest.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrTest.java
@@ -35,44 +35,28 @@ public class ZarrTest {
         Files.createDirectory(TESTOUTPUT);
     }
 
+    /**
+     * Every data type zarr-java implements, so a newly added one is automatically covered by every
+     * test that uses this provider.
+     *
+     * <p>This used to be a hand-written list of enum constants, which meant a new data type was only
+     * tested if someone remembered to extend the list here as well. Deriving it from the enum
+     * removes that step -- and removes the chance of forgetting it.
+     *
+     * <p>Note what this provider still cannot tell you: it enumerates our own enum, so a data type
+     * we never implemented does not appear and no test built on it can fail. Detecting that class of
+     * gap needs a list from outside our code, which is what {@link DataTypeConformanceTest} does.
+     */
     static Stream<DataType> dataTypeProviderV3() {
-        return Stream.of(
-                DataType.BOOL,
-                DataType.INT8,
-                DataType.UINT8,
-                DataType.INT16,
-                DataType.UINT16,
-                DataType.INT32,
-                DataType.UINT32,
-                DataType.INT64,
-                DataType.UINT64,
-                DataType.FLOAT32,
-                DataType.FLOAT64
-        );
+        return Stream.of(DataType.values());
     }
 
+    /**
+     * Every v2 data type zarr-java implements. See {@link #dataTypeProviderV3()} for why this is
+     * derived from the enum rather than hand-listed.
+     */
     static Stream<dev.zarr.zarrjava.v2.DataType> dataTypeProviderV2() {
-        return Stream.of(
-                dev.zarr.zarrjava.v2.DataType.BOOL,
-                dev.zarr.zarrjava.v2.DataType.INT8,
-                dev.zarr.zarrjava.v2.DataType.UINT8,
-                dev.zarr.zarrjava.v2.DataType.INT16,
-                dev.zarr.zarrjava.v2.DataType.UINT16,
-                dev.zarr.zarrjava.v2.DataType.INT32,
-                dev.zarr.zarrjava.v2.DataType.UINT32,
-                dev.zarr.zarrjava.v2.DataType.INT64,
-                dev.zarr.zarrjava.v2.DataType.UINT64,
-                dev.zarr.zarrjava.v2.DataType.FLOAT32,
-                dev.zarr.zarrjava.v2.DataType.FLOAT64,
-                dev.zarr.zarrjava.v2.DataType.UINT16_BE,
-                dev.zarr.zarrjava.v2.DataType.UINT32_BE,
-                dev.zarr.zarrjava.v2.DataType.UINT64_BE,
-                dev.zarr.zarrjava.v2.DataType.INT16_BE,
-                dev.zarr.zarrjava.v2.DataType.INT32_BE,
-                dev.zarr.zarrjava.v2.DataType.INT64_BE,
-                dev.zarr.zarrjava.v2.DataType.FLOAT32_BE,
-                dev.zarr.zarrjava.v2.DataType.FLOAT64_BE
-        );
+        return Stream.of(dev.zarr.zarrjava.v2.DataType.values());
     }
 
     protected void assertListEquals(List<Object> a, List<Object> b) {

--- a/src/test/java/dev/zarr/zarrjava/ZarrV2Test.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrV2Test.java
@@ -110,7 +110,7 @@ public class ZarrV2Test extends ZarrTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"BOOL", "INT8", "UINT8", "INT16", "UINT16", "INT32", "UINT32", "INT64", "UINT64", "FLOAT32", "FLOAT64", "INT16_BE", "UINT16_BE", "INT32_BE", "UINT32_BE", "INT64_BE", "UINT64_BE", "FLOAT32_BE", "FLOAT64_BE"})
+    @MethodSource("dataTypeProviderV2")
     public void testNoFillValue(DataType dataType) throws IOException, ZarrException {
         StoreHandle storeHandle = new FilesystemStore(TESTOUTPUT).resolve("v2_no_fillvalue", dataType.name());
 

--- a/src/test/java/dev/zarr/zarrjava/ZarrV3Test.java
+++ b/src/test/java/dev/zarr/zarrjava/ZarrV3Test.java
@@ -119,21 +119,24 @@ public class ZarrV3Test extends ZarrTest {
         return builder.build();
     }
 
+    /**
+     * Every multi-byte data type crossed with both byte orders.
+     *
+     * <p>Derived from {@link #dataTypeProviderV3()} rather than hand-listed, so a newly added data
+     * type is covered without anyone having to remember this provider. Single-byte data types are
+     * filtered out because byte order is meaningless for them -- {@code core.BytesCodec} skips the
+     * swap entirely when the itemsize is 1.
+     *
+     * <p>The previous hand-written list had already drifted: it omitted {@code INT64} and
+     * {@code UINT64}, so 8-byte byte-order handling went untested.
+     */
     static Stream<Arguments> dataTypeAndEndianProvider() {
-        return Stream.of(
-                Arguments.of(DataType.INT16, BytesCodec.Endian.LITTLE),
-                Arguments.of(DataType.INT16, BytesCodec.Endian.BIG),
-                Arguments.of(DataType.UINT16, BytesCodec.Endian.LITTLE),
-                Arguments.of(DataType.UINT16, BytesCodec.Endian.BIG),
-                Arguments.of(DataType.INT32, BytesCodec.Endian.LITTLE),
-                Arguments.of(DataType.INT32, BytesCodec.Endian.BIG),
-                Arguments.of(DataType.UINT32, BytesCodec.Endian.LITTLE),
-                Arguments.of(DataType.UINT32, BytesCodec.Endian.BIG),
-                Arguments.of(DataType.FLOAT32, BytesCodec.Endian.LITTLE),
-                Arguments.of(DataType.FLOAT32, BytesCodec.Endian.BIG),
-                Arguments.of(DataType.FLOAT64, BytesCodec.Endian.LITTLE),
-                Arguments.of(DataType.FLOAT64, BytesCodec.Endian.BIG)
-        );
+        return dataTypeProviderV3()
+                .filter(dataType -> dataType.getByteCount() > 1)
+                .flatMap(dataType -> Stream.of(
+                        Arguments.of(dataType, BytesCodec.Endian.LITTLE),
+                        Arguments.of(dataType, BytesCodec.Endian.BIG)
+                ));
     }
 
     @ParameterizedTest

--- a/src/test/python-scripts/generate_spec_data_types.py
+++ b/src/test/python-scripts/generate_spec_data_types.py
@@ -1,0 +1,107 @@
+"""Regenerate the external Zarr v3 data-type conformance list.
+
+The list this emits is deliberately NOT derived from zarr-java's own
+``DataType`` enum. Deriving it from our enum would make the conformance test a
+tautology: it could only ever assert that what we implemented is implemented,
+so a data type we never added stays invisible. Instead we take the list from a
+reference implementation (zarr-python), which tells us what will realistically
+show up in stores that other tools have written.
+
+Usage (from the repository root):
+
+    uv run src/test/python-scripts/generate_spec_data_types.py
+
+Writes ``src/test/resources/spec-data-types-v3.json``. The output is committed
+so the Java conformance test runs offline, with no Python involved. Re-run this
+when zarr-python is upgraded -- the nightly ``interop`` job is the natural place
+to notice that it has drifted.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import zarr
+from zarr.core.dtype import data_type_registry
+
+# Parameterized data types cannot be instantiated with no arguments. These are
+# representative instances -- the point is to capture the JSON *shape* that
+# appears in a real zarr.json, not to enumerate every possible parameterization.
+PARAMETERIZED_ARGS = {
+    "fixed_length_utf32": {"length": 4},
+    "raw_bytes": {"length": 4},
+    "null_terminated_bytes": {"length": 4},
+    "numpy.datetime64": {"unit": "s", "scale_factor": 1},
+    "numpy.timedelta64": {"unit": "s", "scale_factor": 1},
+    "structured": {"fields": (("a", data_type_registry.contents["int32"]()),
+                              ("b", data_type_registry.contents["float64"]()))},
+}
+
+OUT_PATH = Path("src/test/resources/spec-data-types-v3.json")
+
+
+def instantiate(name, cls):
+    """Build a representative instance of a data type, or return None."""
+    try:
+        return cls()
+    except TypeError:
+        pass
+    kwargs = PARAMETERIZED_ARGS.get(name)
+    if kwargs is None:
+        return None
+    try:
+        return cls(**kwargs)
+    except Exception:  # noqa: BLE001 - best effort; reported as skipped below
+        return None
+
+
+def main():
+    entries = []
+    skipped = []
+
+    for name, cls in data_type_registry.contents.items():
+        instance = instantiate(name, cls)
+        if instance is None:
+            skipped.append(name)
+            continue
+        try:
+            data_type_json = instance.to_json(zarr_format=3)
+            fill_value_json = instance.to_json_scalar(
+                instance.default_scalar(), zarr_format=3
+            )
+        except Exception as exc:  # noqa: BLE001
+            skipped.append(f"{name} ({type(exc).__name__})")
+            continue
+
+        entries.append(
+            {
+                "name": name,
+                "data_type": data_type_json,
+                "fill_value": fill_value_json,
+            }
+        )
+
+    document = {
+        "_comment": (
+            "GENERATED FILE -- do not edit by hand. Regenerate with "
+            "'uv run src/test/python-scripts/generate_spec_data_types.py'. "
+            "This is the external conformance list for "
+            "DataTypeConformanceTest; it is intentionally not derived from "
+            "zarr-java's DataType enum."
+        ),
+        "source": f"zarr-python {zarr.__version__} data_type_registry",
+        "data_types": entries,
+    }
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(document, indent=2, sort_keys=False) + "\n")
+
+    print(f"wrote {OUT_PATH} with {len(entries)} data types "
+          f"(zarr-python {zarr.__version__})")
+    if skipped:
+        print(f"skipped (could not instantiate): {', '.join(skipped)}",
+              file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/python-scripts/zarr_fixtures.py
+++ b/src/test/python-scripts/zarr_fixtures.py
@@ -1,0 +1,182 @@
+"""Shared zarr-python fixture operations used by the interop tests.
+
+Every operation the Java interop suite asks of zarr-python lives here as a
+function, so the one-shot CLI scripts and the long-lived worker
+(``zarr_python_worker.py``) execute literally the same code. That matters: the
+worker exists purely to avoid paying ``import zarr`` once per test case, and it
+would be worthless if it could drift from the behaviour the CLI scripts had.
+
+Each function either returns normally or raises. Assertion messages are
+preserved verbatim from the original scripts so failure output is unchanged.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import zarr
+from zarr.storage import LocalStore
+
+from parse_codecs import parse_codecs_zarr_python
+
+SHAPE = (16, 16, 16)
+CHUNKS = (2, 4, 8)
+
+
+def _testdata_v3(dtype):
+    if dtype == 'bool':
+        return np.arange(16 * 16 * 16, dtype='uint8').reshape(16, 16, 16) % 2 == 0
+    return np.arange(16 * 16 * 16, dtype=dtype).reshape(16, 16, 16)
+
+
+def _testdata_v2(dtype):
+    if 'b1' in dtype:
+        return np.arange(16 * 16 * 16, dtype='uint8').reshape(16, 16, 16) % 2 == 0
+    return np.arange(16 * 16 * 16, dtype=dtype).reshape(16, 16, 16)
+
+
+def write_v3(codec_string, param_string, dtype, store_path):
+    """Write a v3 array with zarr-python for zarr-java to read back."""
+    compressor, serializer, filters = parse_codecs_zarr_python(codec_string, param_string)
+    store_path = Path(store_path)
+    testdata = _testdata_v3(dtype)
+
+    a = zarr.create_array(
+        LocalStore(store_path),
+        shape=SHAPE,
+        chunks=CHUNKS,
+        dtype=dtype,
+        filters=filters,
+        serializer=serializer,
+        compressors=compressor,
+        attributes={'answer': 42}
+    )
+    a[:, :] = testdata
+
+
+def read_v3(codec_string, param_string, dtype, store_path):
+    """Verify with zarr-python that a v3 array zarr-java wrote is correct."""
+    compressor, serializer, filters = parse_codecs_zarr_python(codec_string, param_string)
+    store_path = Path(store_path)
+    expected_data = _testdata_v3(dtype)
+
+    a = zarr.open_array(store=LocalStore(store_path))
+    read_data = a[:, :]
+    assert np.array_equal(read_data, expected_data), \
+        f"got:\n {read_data} \nbut expected:\n {expected_data}"
+
+    b = zarr.create_array(
+        LocalStore(store_path / "expected"),
+        shape=SHAPE,
+        chunks=CHUNKS,
+        dtype=dtype,
+        fill_value=0,
+        filters=filters,
+        serializer=serializer,
+        compressors=compressor,
+        attributes={'test_key': 'test_value'},
+        overwrite=True,
+    )
+
+    assert a.metadata == b.metadata, f"not equal: \n{a.metadata=}\n{b.metadata=}"
+
+
+def write_v2(codec_string, param_string, dtype, store_path):
+    """Write a v2 array with zarr-python for zarr-java to read back."""
+    compressor, serializer, filters = parse_codecs_zarr_python(
+        codec_string, param_string, zarr_version=2)
+    store_path = Path(store_path)
+    testdata = _testdata_v2(dtype)
+
+    a = zarr.create_array(
+        LocalStore(store_path),
+        zarr_format=2,
+        shape=SHAPE,
+        chunks=CHUNKS,
+        dtype=dtype,
+        filters=filters,
+        serializer=serializer,
+        compressors=compressor,
+        attributes={'answer': 42}
+    )
+    a[:, :] = testdata
+
+
+def read_v2(codec_string, param_string, dtype, store_path):
+    """Verify with zarr-python that a v2 array zarr-java wrote is correct."""
+    compressor, serializer, filters = parse_codecs_zarr_python(
+        codec_string, param_string, zarr_version=2)
+    store_path = Path(store_path)
+    expected_data = _testdata_v2(dtype)
+
+    a = zarr.open_array(store=LocalStore(store_path))
+    read_data = a[:, :]
+    assert np.array_equal(read_data, expected_data), \
+        f"got:\n {read_data} \nbut expected:\n {expected_data}"
+
+    b = zarr.create_array(
+        LocalStore(store_path / "expected"),
+        zarr_format=2,
+        shape=SHAPE,
+        chunks=CHUNKS,
+        dtype=dtype,
+        fill_value=0,
+        filters=filters,
+        serializer=serializer,
+        compressors=compressor,
+        attributes={'test_key': 'test_value'},
+        overwrite=True,
+    )
+
+    assert a.metadata == b.metadata, f"not equal: \n{a.metadata=}\n{b.metadata=}"
+
+
+def group(store_path_read, store_path_write, zarr_format):
+    """Read a group zarr-java wrote, then write one for zarr-java to read."""
+    store_path_read = Path(store_path_read)
+    store_path_write = Path(store_path_write)
+    zarr_format = int(zarr_format)
+    assert zarr_format in (2, 3), f"unexpected zarr format: {zarr_format}"
+
+    expected_data = np.arange(16 * 16 * 16, dtype='int32').reshape(16, 16, 16)
+
+    g = zarr.open_group(store=LocalStore(store_path_read), zarr_format=zarr_format)
+    assert g.attrs['attr'] == 'value'
+    a = g['group']['array']
+    read_data = a[:, :]
+    assert np.array_equal(read_data, expected_data), \
+        f"got:\n {read_data} \nbut expected:\n {expected_data}"
+
+    g2 = zarr.create_group(store=LocalStore(store_path_write), zarr_format=zarr_format,
+                           overwrite=True)
+    g2.attrs['attr'] = 'value'
+    a2 = g2.create_group('group2').create_array(
+        name='array2',
+        shape=SHAPE,
+        chunks=CHUNKS,
+        dtype="int32",
+        fill_value=0,
+    )
+    a2[:] = expected_data
+
+
+def zstd_decompress(data_path, expected):
+    """Check that zarr-java's zstd output decompresses to the expected integer."""
+    import zstandard as zstd
+
+    with open(data_path, "rb") as f:
+        compressed = f.read()
+
+    decompressed = zstd.ZstdDecompressor().decompress(compressed)
+    number = int.from_bytes(decompressed, byteorder='big')
+    assert number == int(expected)
+
+
+#: Operations the worker exposes, by name.
+OPERATIONS = {
+    "write_v3": write_v3,
+    "read_v3": read_v3,
+    "write_v2": write_v2,
+    "read_v2": read_v2,
+    "group": group,
+    "zstd_decompress": zstd_decompress,
+}

--- a/src/test/python-scripts/zarr_python_group.py
+++ b/src/test/python-scripts/zarr_python_group.py
@@ -1,29 +1,12 @@
-import numpy as np
+"""Round-trip a group through zarr-python. One-shot CLI wrapper.
+
+See zarr_python_write.py for why the suite prefers zarr_python_worker.py.
+
+    uv run src/test/python-scripts/zarr_python_group.py /tmp/written /tmp/toread 3
+"""
+
 import sys
-import zarr
-from pathlib import Path
-from zarr.storage import LocalStore
 
-store_path_read = Path(sys.argv[1])
-store_path_write = Path(sys.argv[2])
-zarr_format = int(sys.argv[3])
-assert zarr_format in (2, 3), f"unexpected zarr format: {zarr_format}"
+from zarr_fixtures import group
 
-expected_data = np.arange(16 * 16 * 16, dtype='int32').reshape(16, 16, 16)
-
-g = zarr.open_group(store=LocalStore(store_path_read), zarr_format=zarr_format)
-assert g.attrs['attr'] == 'value'
-a = g['group']['array']
-read_data = a[:, :]
-assert np.array_equal(read_data, expected_data), f"got:\n {read_data} \nbut expected:\n {expected_data}"
-
-g2 = zarr.create_group(store=LocalStore(store_path_write), zarr_format=zarr_format)
-g2.attrs['attr'] = 'value'
-a2 = g2.create_group('group2').create_array(
-    name='array2',
-    shape=(16, 16, 16),
-    chunks=(2, 4, 8),
-    dtype="int32",
-    fill_value=0,
-)
-a2[:] = expected_data
+group(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/src/test/python-scripts/zarr_python_read.py
+++ b/src/test/python-scripts/zarr_python_read.py
@@ -1,36 +1,12 @@
-import numpy as np
+"""Verify a v3 array zarr-java wrote. One-shot CLI wrapper.
+
+See zarr_python_write.py for why the suite prefers zarr_python_worker.py.
+
+    uv run src/test/python-scripts/zarr_python_read.py blosc blosclz_shuffle_3 int32 /tmp/store
+"""
+
 import sys
-import zarr
-from pathlib import Path
-from zarr.storage import LocalStore
 
-from parse_codecs import parse_codecs_zarr_python
+from zarr_fixtures import read_v3
 
-codec_string = sys.argv[1]
-param_string = sys.argv[2]
-compressor, serializer, filters = parse_codecs_zarr_python(codec_string, param_string)
-dtype = sys.argv[3]
-store_path = Path(sys.argv[4])
-
-if dtype == 'bool':
-    expected_data = np.arange(16 * 16 * 16, dtype='uint8').reshape(16, 16, 16) % 2 == 0
-else:
-    expected_data = np.arange(16 * 16 * 16, dtype=dtype).reshape(16, 16, 16)
-
-a = zarr.open_array(store=LocalStore(store_path))
-read_data = a[:, :]
-assert np.array_equal(read_data, expected_data), f"got:\n {read_data} \nbut expected:\n {expected_data}"
-
-b = zarr.create_array(
-    LocalStore(store_path / "expected"),
-    shape=(16, 16, 16),
-    chunks=(2, 4, 8),
-    dtype=dtype,
-    fill_value=0,
-    filters=filters,
-    serializer=serializer,
-    compressors=compressor,
-    attributes={'test_key': 'test_value'},
-)
-
-assert a.metadata == b.metadata, f"not equal: \n{a.metadata=}\n{b.metadata=}"
+read_v3(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/src/test/python-scripts/zarr_python_read_v2.py
+++ b/src/test/python-scripts/zarr_python_read_v2.py
@@ -1,37 +1,12 @@
-import numpy as np
+"""Verify a v2 array zarr-java wrote. One-shot CLI wrapper.
+
+See zarr_python_write.py for why the suite prefers zarr_python_worker.py.
+
+    uv run src/test/python-scripts/zarr_python_read_v2.py zlib 0 '<i4' /tmp/store
+"""
+
 import sys
-import zarr
-from pathlib import Path
-from zarr.storage import LocalStore
 
-from parse_codecs import parse_codecs_zarr_python
+from zarr_fixtures import read_v2
 
-codec_string = sys.argv[1]
-param_string = sys.argv[2]
-compressor, serializer, filters = parse_codecs_zarr_python(codec_string, param_string, zarr_version=2)
-dtype = sys.argv[3]
-store_path = Path(sys.argv[4])
-
-if 'b1' in dtype:
-    expected_data = np.arange(16 * 16 * 16, dtype='uint8').reshape(16, 16, 16) % 2 == 0
-else:
-    expected_data = np.arange(16 * 16 * 16, dtype=dtype).reshape(16, 16, 16)
-
-a = zarr.open_array(store=LocalStore(store_path))
-read_data = a[:, :]
-assert np.array_equal(read_data, expected_data), f"got:\n {read_data} \nbut expected:\n {expected_data}"
-
-b = zarr.create_array(
-    LocalStore(store_path / "expected"),
-    zarr_format=2,
-    shape=(16, 16, 16),
-    chunks=(2, 4, 8),
-    dtype=dtype,
-    fill_value=0,
-    filters=filters,
-    serializer=serializer,
-    compressors=compressor,
-    attributes={'test_key': 'test_value'},
-)
-
-assert a.metadata == b.metadata, f"not equal: \n{a.metadata=}\n{b.metadata=}"
+read_v2(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/src/test/python-scripts/zarr_python_worker.py
+++ b/src/test/python-scripts/zarr_python_worker.py
@@ -1,0 +1,92 @@
+"""Long-lived zarr-python worker for the Java interop tests.
+
+Why this exists: the interop suite used to spawn one ``uv run`` per test case,
+and each launch paid the cost of starting an interpreter and importing zarr and
+numpy. With ~78 v3 cases alone (each dtype crossed with a couple of codecs, plus
+the codec matrix, in both directions) that startup cost dominated the suite --
+the arrays themselves are 16 KB and take no measurable time. Batching the Python
+side into a single process removes it.
+
+A persistent worker was chosen over "generate every fixture up front in one
+script" because it keeps per-test semantics exactly as they were: each test still
+triggers its own zarr-python call and asserts on its own result, so a failure is
+reported against the test that caused it rather than against an aggregate setup
+step.
+
+Protocol: one JSON object per line on stdin, one JSON object per line on stdout.
+
+    -> {"op": "write_v3", "args": ["blosc", "blosclz_shuffle_3", "int32", "/tmp/x"]}
+    <- {"ok": true}
+
+    -> {"op": "read_v3", "args": [...]}
+    <- {"ok": false, "error": "AssertionError: got: ... but expected: ..."}
+
+    -> {"op": "ping"}      <- {"ok": true}          (readiness handshake)
+    -> {"op": "shutdown"}  (no response; process exits)
+
+Anything an operation prints, and any warning it emits, is redirected to stderr
+so it cannot corrupt the protocol stream on stdout.
+"""
+
+import contextlib
+import io
+import json
+import sys
+import traceback
+
+from zarr_fixtures import OPERATIONS
+
+
+def _handle(request):
+    op_name = request.get("op")
+
+    if op_name == "ping":
+        return {"ok": True}
+
+    operation = OPERATIONS.get(op_name)
+    if operation is None:
+        return {"ok": False, "error": f"unknown op: {op_name!r}"}
+
+    args = request.get("args", [])
+    captured = io.StringIO()
+    try:
+        # Keep operation chatter off the protocol stream.
+        with contextlib.redirect_stdout(captured):
+            operation(*args)
+    except Exception:  # noqa: BLE001 - every failure is reported to the caller
+        return {"ok": False, "error": traceback.format_exc()}
+    finally:
+        chatter = captured.getvalue()
+        if chatter:
+            sys.stderr.write(chatter)
+            sys.stderr.flush()
+
+    return {"ok": True}
+
+
+def main():
+    # Hold the real stdout for protocol replies; operations get a redirected one.
+    protocol_out = sys.stdout
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            request = json.loads(line)
+        except ValueError as exc:
+            protocol_out.write(json.dumps({"ok": False, "error": f"bad request: {exc}"}) + "\n")
+            protocol_out.flush()
+            continue
+
+        if request.get("op") == "shutdown":
+            return
+
+        response = _handle(request)
+        protocol_out.write(json.dumps(response) + "\n")
+        protocol_out.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/python-scripts/zarr_python_write.py
+++ b/src/test/python-scripts/zarr_python_write.py
@@ -1,30 +1,14 @@
-import numpy as np
+"""Write a v3 array with zarr-python. One-shot CLI wrapper.
+
+The interop suite normally drives this through zarr_python_worker.py to avoid
+paying interpreter startup per test case; this entry point is kept for running a
+single case by hand:
+
+    uv run src/test/python-scripts/zarr_python_write.py blosc blosclz_shuffle_3 int32 /tmp/store
+"""
+
 import sys
-import zarr
-from pathlib import Path
-from zarr.storage import LocalStore
 
-from parse_codecs import parse_codecs_zarr_python
+from zarr_fixtures import write_v3
 
-codec_string = sys.argv[1]
-param_string = sys.argv[2]
-compressor, serializer, filters = parse_codecs_zarr_python(codec_string, param_string)
-dtype = sys.argv[3]
-store_path = Path(sys.argv[4])
-
-if dtype == 'bool':
-    testdata = np.arange(16 * 16 * 16, dtype='uint8').reshape(16, 16, 16) % 2 == 0
-else:
-    testdata = np.arange(16 * 16 * 16, dtype=dtype).reshape(16, 16, 16)
-
-a = zarr.create_array(
-    LocalStore(store_path),
-    shape=(16, 16, 16),
-    chunks=(2, 4, 8),
-    dtype=dtype,
-    filters=filters,
-    serializer=serializer,
-    compressors=compressor,
-    attributes={'answer': 42}
-)
-a[:, :] = testdata
+write_v3(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/src/test/python-scripts/zarr_python_write_v2.py
+++ b/src/test/python-scripts/zarr_python_write_v2.py
@@ -1,31 +1,12 @@
-import numpy as np
+"""Write a v2 array with zarr-python. One-shot CLI wrapper.
+
+See zarr_python_write.py for why the suite prefers zarr_python_worker.py.
+
+    uv run src/test/python-scripts/zarr_python_write_v2.py zlib 0 '<i4' /tmp/store
+"""
+
 import sys
-import zarr
-from pathlib import Path
-from zarr.storage import LocalStore
 
-from parse_codecs import parse_codecs_zarr_python
+from zarr_fixtures import write_v2
 
-codec_string = sys.argv[1]
-param_string = sys.argv[2]
-compressor, serializer, filters = parse_codecs_zarr_python(codec_string, param_string, zarr_version=2)
-dtype = sys.argv[3]
-store_path = Path(sys.argv[4])
-
-if 'b1' in dtype:
-    testdata = np.arange(16 * 16 * 16, dtype='uint8').reshape(16, 16, 16) % 2 == 0
-else:
-    testdata = np.arange(16 * 16 * 16, dtype=dtype).reshape(16, 16, 16)
-
-a = zarr.create_array(
-    LocalStore(store_path),
-    zarr_format=2,
-    shape=(16, 16, 16),
-    chunks=(2, 4, 8),
-    dtype=dtype,
-    filters=filters,
-    serializer=serializer,
-    compressors=compressor,
-    attributes={'answer': 42}
-)
-a[:, :] = testdata
+write_v2(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])

--- a/src/test/python-scripts/zstd_decompress.py
+++ b/src/test/python-scripts/zstd_decompress.py
@@ -1,13 +1,12 @@
+"""Check zarr-java's zstd output with the reference library. One-shot CLI wrapper.
+
+See zarr_python_write.py for why the suite prefers zarr_python_worker.py.
+
+    uv run src/test/python-scripts/zstd_decompress.py /tmp/compressed.bin 123456
+"""
+
 import sys
 
-import zstandard as zstd
+from zarr_fixtures import zstd_decompress
 
-data_path = sys.argv[1]
-expected = sys.argv[2]
-
-with open(data_path, "rb") as f:
-    compressed = f.read()
-
-decompressed = zstd.ZstdDecompressor().decompress(compressed)
-number = int.from_bytes(decompressed, byteorder='big')
-assert number == int(expected)
+zstd_decompress(sys.argv[1], sys.argv[2])

--- a/src/test/resources/spec-data-types-v3.json
+++ b/src/test/resources/spec-data-types-v3.json
@@ -1,0 +1,163 @@
+{
+  "_comment": "GENERATED FILE -- do not edit by hand. Regenerate with 'uv run src/test/python-scripts/generate_spec_data_types.py'. This is the external conformance list for DataTypeConformanceTest; it is intentionally not derived from zarr-java's DataType enum.",
+  "source": "zarr-python 3.1.6 data_type_registry",
+  "data_types": [
+    {
+      "name": "bool",
+      "data_type": "bool",
+      "fill_value": false
+    },
+    {
+      "name": "int8",
+      "data_type": "int8",
+      "fill_value": 0
+    },
+    {
+      "name": "int16",
+      "data_type": "int16",
+      "fill_value": 0
+    },
+    {
+      "name": "int32",
+      "data_type": "int32",
+      "fill_value": 0
+    },
+    {
+      "name": "int64",
+      "data_type": "int64",
+      "fill_value": 0
+    },
+    {
+      "name": "uint8",
+      "data_type": "uint8",
+      "fill_value": 0
+    },
+    {
+      "name": "uint16",
+      "data_type": "uint16",
+      "fill_value": 0
+    },
+    {
+      "name": "uint32",
+      "data_type": "uint32",
+      "fill_value": 0
+    },
+    {
+      "name": "uint64",
+      "data_type": "uint64",
+      "fill_value": 0
+    },
+    {
+      "name": "float16",
+      "data_type": "float16",
+      "fill_value": 0.0
+    },
+    {
+      "name": "float32",
+      "data_type": "float32",
+      "fill_value": 0.0
+    },
+    {
+      "name": "float64",
+      "data_type": "float64",
+      "fill_value": 0.0
+    },
+    {
+      "name": "complex64",
+      "data_type": "complex64",
+      "fill_value": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "name": "complex128",
+      "data_type": "complex128",
+      "fill_value": [
+        0.0,
+        0.0
+      ]
+    },
+    {
+      "name": "fixed_length_utf32",
+      "data_type": {
+        "name": "fixed_length_utf32",
+        "configuration": {
+          "length_bytes": 16
+        }
+      },
+      "fill_value": ""
+    },
+    {
+      "name": "string",
+      "data_type": "string",
+      "fill_value": ""
+    },
+    {
+      "name": "raw_bytes",
+      "data_type": {
+        "name": "raw_bytes",
+        "configuration": {
+          "length_bytes": 4
+        }
+      },
+      "fill_value": "AAAAAA=="
+    },
+    {
+      "name": "null_terminated_bytes",
+      "data_type": {
+        "name": "null_terminated_bytes",
+        "configuration": {
+          "length_bytes": 4
+        }
+      },
+      "fill_value": ""
+    },
+    {
+      "name": "variable_length_bytes",
+      "data_type": "variable_length_bytes",
+      "fill_value": ""
+    },
+    {
+      "name": "structured",
+      "data_type": {
+        "name": "structured",
+        "configuration": {
+          "fields": [
+            [
+              "a",
+              "int32"
+            ],
+            [
+              "b",
+              "float64"
+            ]
+          ]
+        }
+      },
+      "fill_value": "AAAAAAAAAAAAAAAA"
+    },
+    {
+      "name": "numpy.datetime64",
+      "data_type": {
+        "name": "numpy.datetime64",
+        "configuration": {
+          "unit": "generic",
+          "scale_factor": 1
+        }
+      },
+      "fill_value": -9223372036854775808
+    },
+    {
+      "name": "numpy.timedelta64",
+      "data_type": {
+        "name": "numpy.timedelta64",
+        "configuration": {
+          "unit": "generic",
+          "scale_factor": 1
+        }
+      },
+      "fill_value": -9223372036854775808
+    }
+  ]
+}


### PR DESCRIPTION
The dtype test providers mirrored our own DataType enum by hand, which made
them tautological: they could only assert that what we implemented is
implemented, so a data type we never added was invisible and no test could
fail for it. That is how float16 and string went unnoticed despite a broad
interop matrix.

Drive coverage from outside our code instead:

- New DataTypeConformanceTest checks our enum against a list generated from
  zarr-python's data type registry and committed alongside it. What we lack is
  enumerated in KNOWN_UNSUPPORTED with a note on what each needs, and the
  assertion is bidirectional, so implementing a data type shows up as a
  deletion there and a stale entry fails too. Metadata-only: no I/O and no
  Python.
- Two CI jobs keep that list current, split by who caused the problem. Per
  pull request it is checked against the zarr-python we pin; nightly, against
  the latest release. The nightly one is deliberately not a pull-request gate,
  since no pull request causes upstream to publish a version.

Also cut the interop tier's cost. It ran one `uv run` per test case, paying
interpreter startup plus `import zarr, numpy` every time; the test arrays were
never the expense. zarr-python now runs as one long-lived worker speaking JSON
lines over stdin/stdout. A worker rather than an up-front batch keeps per-test
semantics, so failures stay attributed to the test that caused them. Fixture
logic moved to zarr_fixtures.py, which both the worker and the CLI scripts
call, so the two cannot drift.

Full interop run: 129.3s -> 19.2s.