### PR TITLE
Support open-ended ranges in getInputStream, fail loudly on unreadable zip archives

### DIFF
--- a/src/main/java/dev/zarr/zarrjava/store/HttpStore.java
+++ b/src/main/java/dev/zarr/zarrjava/store/HttpStore.java
@@ -128,8 +128,12 @@ public class HttpStore implements Store {
         if (start < 0) {
             throw new IllegalArgumentException("Argument 'start' needs to be non-negative.");
         }
-        Request request = new Request.Builder().url(resolveKeys(keys)).header(
-                "Range", String.format("bytes=%d-%d", start, end - 1)).build();
+        // A negative end means "until the end of the object", which HTTP expresses as an
+        // open-ended range.
+        String range = end < 0
+                ? String.format("bytes=%d-", start)
+                : String.format("bytes=%d-%d", start, end - 1);
+        Request request = new Request.Builder().url(resolveKeys(keys)).header("Range", range).build();
 
         try {
             // We do NOT use try-with-resources here because the stream must remain open

--- a/src/main/java/dev/zarr/zarrjava/store/ReadOnlyZipStore.java
+++ b/src/main/java/dev/zarr/zarrjava/store/ReadOnlyZipStore.java
@@ -50,8 +50,10 @@ public class ReadOnlyZipStore extends ZipStore {
 
         InputStream inputStream = underlyingStore.getInputStream();
         if (inputStream == null) {
-            isCached = true;
-            return;
+            throw StoreException.readFailed(
+                    underlyingStore.toString(),
+                    new String[]{},
+                    new IOException("Could not open the ZIP archive from the underlying store"));
         }
 
         try (ZipArchiveInputStream zis = new ZipArchiveInputStream(inputStream)) {

--- a/src/main/java/dev/zarr/zarrjava/store/S3Store.java
+++ b/src/main/java/dev/zarr/zarrjava/store/S3Store.java
@@ -103,10 +103,17 @@ public class S3Store implements Store, Store.ListableStore {
     @Nullable
     @Override
     public ByteBuffer get(String[] keys, long start, long end) {
+        if (start < 0) {
+            throw new IllegalArgumentException("Argument 'start' needs to be non-negative.");
+        }
+        // S3 ranges are inclusive; a negative end means "until the end of the object".
+        String range = end < 0
+                ? String.format("bytes=%d-", start)
+                : String.format("bytes=%d-%d", start, end - 1);
         GetObjectRequest req = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(resolveKeys(keys))
-                .range(String.format("bytes=%d-%d", start, end - 1)) // S3 range is inclusive
+                .range(range)
                 .build();
         return get(req);
     }
@@ -221,10 +228,17 @@ public class S3Store implements Store, Store.ListableStore {
 
     @Override
     public InputStream getInputStream(String[] keys, long start, long end) {
+        if (start < 0) {
+            throw new IllegalArgumentException("Argument 'start' needs to be non-negative.");
+        }
+        // S3 ranges are inclusive; a negative end means "until the end of the object".
+        String range = end < 0
+                ? String.format("bytes=%d-", start)
+                : String.format("bytes=%d-%d", start, end - 1);
         GetObjectRequest req = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(resolveKeys(keys))
-                .range(String.format("bytes=%d-%d", start, end - 1)) // S3 range is inclusive
+                .range(range)
                 .build();
         return s3client.getObject(req);
     }

--- a/src/test/java/dev/zarr/zarrjava/store/HttpStoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/HttpStoreTest.java
@@ -87,6 +87,28 @@ class HttpStoreTest extends StoreTest {
         }
     }
 
+    @Test
+    public void testOpenEndedRangeHeader() throws IOException, InterruptedException {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setBody("data").setResponseCode(206));
+            server.start();
+            HttpStore httpStore = new HttpStore(server.url("/").toString(), 1, 3, 10);
+            Assertions.assertNotNull(httpStore.getInputStream(new String[]{"path"}, 0, -1));
+            Assertions.assertEquals("bytes=0-", server.takeRequest().getHeader("Range"));
+        }
+    }
+
+    @Test
+    public void testBoundedRangeHeader() throws IOException, InterruptedException {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setBody("dat").setResponseCode(206));
+            server.start();
+            HttpStore httpStore = new HttpStore(server.url("/").toString(), 1, 3, 10);
+            Assertions.assertNotNull(httpStore.getInputStream(new String[]{"path"}, 1, 4));
+            Assertions.assertEquals("bytes=1-3", server.takeRequest().getHeader("Range"));
+        }
+    }
+
     @Override
     @Test
     @Disabled("List is not supported in HttpStore")

--- a/src/test/java/dev/zarr/zarrjava/store/ReadOnlyZipStoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/ReadOnlyZipStoreTest.java
@@ -42,6 +42,13 @@ public class ReadOnlyZipStoreTest extends StoreTest {
     }
 
 
+    @Test
+    public void testUnreadableArchiveThrows() {
+        ReadOnlyZipStore zipStore = new ReadOnlyZipStore(TESTOUTPUT.resolve("does_not_exist.zip"));
+        Assertions.assertThrows(StoreException.class, () -> zipStore.resolve().listChildren().count());
+        Assertions.assertThrows(StoreException.class, () -> zipStore.resolve("array", "0.0.0").exists());
+    }
+
     @Override
     @Test
     public void testListChildren() {

--- a/src/test/java/dev/zarr/zarrjava/store/StoreTest.java
+++ b/src/test/java/dev/zarr/zarrjava/store/StoreTest.java
@@ -47,6 +47,29 @@ public abstract class StoreTest extends ZarrTest {
     }
 
     @Test
+    public void testInputStreamOpenEnded() throws IOException {
+        StoreHandle storeHandle = storeHandleWithData();
+        ByteBuffer expected = storeHandle.read();
+        try (InputStream is = storeHandle.getInputStream()) {
+            Assertions.assertNotNull(is, "Open-ended getInputStream() returned null");
+            byte[] actual = readFully(is);
+            byte[] expectedBytes = new byte[expected.remaining()];
+            expected.get(expectedBytes);
+            Assertions.assertArrayEquals(expectedBytes, actual);
+        }
+    }
+
+    private static byte[] readFully(InputStream is) throws IOException {
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int len;
+        while ((len = is.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        return baos.toByteArray();
+    }
+
+    @Test
     public void testExists() throws ZarrException, IOException {
         Assertions.assertTrue(storeHandleWithData().exists());
         Assertions.assertFalse(storeHandleWithoutData().exists());


### PR DESCRIPTION
Fixes #100 and #101.

## `HttpStore.getInputStream` and open-ended ranges (#100)

`getInputStream(keys, start, end)` formatted `bytes=%d-%d` unconditionally. Since `Store.getInputStream(keys)` delegates to `getInputStream(keys, 0, -1)`, that became `Range: bytes=0--1` — which no server answers, so the method returned `null`. It now emits `bytes=<start>-` when `end` is negative, mirroring what `get(keys, start)` already did.

`S3Store.getInputStream` built the same range string and had the identical bug, so it is fixed the same way (and now validates a non-negative `start`, matching the other stores).

## `ReadOnlyZipStore` silently reporting an unreadable archive as empty (#101)

`ensureCache()` treated a `null` stream from the underlying store as a successfully-parsed empty archive, so a read failure surfaced as valid-but-empty data — concretely, a misleading `No Zarr group found at …` several layers from the cause. It now throws `StoreException.readFailed(...)`, as it already did for an `IOException` while parsing the ZIP directory. A genuinely empty archive still parses to an empty index through the normal path, so the two cases stay distinguishable.

## Tests

- `StoreTest.testInputStreamOpenEnded` — shared test asserting the default `getInputStream()` returns the full object; runs against every store subclass.
- `HttpStoreTest.testOpenEndedRangeHeader` / `testBoundedRangeHeader` — MockWebServer tests pinning the exact `Range` header (`bytes=0-` and `bytes=1-3`).
- `ReadOnlyZipStoreTest.testUnreadableArchiveThrows` — asserts `StoreException` for a missing archive.

Verified against the reproducer from #100 (`https://static.webknossos.org/misc/6001240.ozx`):

```
getSize: 39374104
get(k,0): 39374104
get(k,-22): 22
getInputStream(k,0,-1): ok, first bytes read=4
zip children:  zarr.json 0 1 2
MISSING ARCHIVE throws: Failed to read from store '.../does-not-exist.ozx' at key '': Could not open the ZIP archive from the underlying store
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)